### PR TITLE
MirrorFormCard improvements

### DIFF
--- a/src/components/create-guild/Requirements/components/MirrorFormCard/MirrorFormCard.tsx
+++ b/src/components/create-guild/Requirements/components/MirrorFormCard/MirrorFormCard.tsx
@@ -110,7 +110,9 @@ const MirrorFormCard = ({ index, field }: Props): JSX.Element => {
                 menuIsOpen={valueInput.length > 2}
                 onInputChange={(text, _) => setValueInput(text)}
                 filterOption={(candidate, input) =>
-                  candidate.label.toLowerCase().includes(input?.toLowerCase())
+                  candidate?.label?.toLowerCase().includes(input?.toLowerCase()) ||
+                  candidate?.value?.toString().startsWith(input) ||
+                  candidate?.data?.address?.toLowerCase() === input.toLowerCase()
                 }
                 // Hiding the dropdown indicator
                 components={{

--- a/src/components/create-guild/Requirements/components/MirrorFormCard/MirrorFormCard.tsx
+++ b/src/components/create-guild/Requirements/components/MirrorFormCard/MirrorFormCard.tsx
@@ -96,11 +96,13 @@ const MirrorFormCard = ({ index, field }: Props): JSX.Element => {
                 placeholder="Search..."
                 value={mappedEditions?.find(
                   (edition) =>
-                    edition.value == selectValue && edition.address === address
+                    edition.value == selectValue &&
+                    edition.address?.toLowerCase() === address
                 )}
                 defaultValue={mappedEditions?.find(
                   (edition) =>
-                    edition.value == field.value && edition.address === field.address
+                    edition.value == field.value &&
+                    edition.address?.toLowerCase() === field.address
                 )}
                 onChange={(newValue) => {
                   onChange(newValue?.value)


### PR DESCRIPTION
Closes #166 
- Users can now search mirror editions by pasting an address (it'll list all editions for that address) or by typing in the edition ID)
- Now MirrorFormCard is filled up with default data properly inside the edit drawers