### PR TITLE
Datadog actions for the new onboarding flow

### DIFF
--- a/src/components/_app/Datadog.tsx
+++ b/src/components/_app/Datadog.tsx
@@ -4,14 +4,18 @@ import { PropsWithChildren, useEffect } from "react"
 
 const Datadog = ({ children }: PropsWithChildren<unknown>): JSX.Element => {
   useEffect(() => {
-    if (process.env.NODE_ENV !== "production") return
+    // if (process.env.NODE_ENV !== "production") return
     datadogRum.init({
-      applicationId: "996b7a2a-d610-4235-a5b4-65391973ea76",
-      clientToken: "pub7cf22f3b79a010363cf58c859cfa8ad8",
+      // applicationId: "996b7a2a-d610-4235-a5b4-65391973ea76",
+      applicationId: "eb05b107-c5ac-490b-addb-67869c1f50a3",
+      // clientToken: "pub7cf22f3b79a010363cf58c859cfa8ad8",
+      clientToken: "pubcb8f3d82e21849dc0d5ed8a8cb24249f",
       site: "datadoghq.eu",
-      service: "guild.xyz",
+      // service: "guild.xyz",
+      service: "guild-xyz-git-datadog-experiments-zgen.vercel.app",
       env: "prod",
-      sampleRate: 60,
+      // sampleRate: 60,
+      sampleRate: 100,
       trackInteractions: true,
       defaultPrivacyLevel: "mask-user-input",
       version: "1.0.0",


### PR DESCRIPTION
## Custom actions todo list

### /create-guild/discord view

- [ ] user picks a Discord server
- [ ] user clicks on the `connect wallet` button (not on the header, but on the card!)
- [ ] user clicks on `sign to submit` button
- [ ] success/error message

If the onboarding panel is active:

- [ ] user clicks on `{num}-next` where `num` is the step number
- [ ] user clicks on `{num}-prev`
- [ ] user clicks on `[onboarding] edit role` - we only need to modify the action in `EditRole.tsx`
- [ ] user clicks on `[onboarding] add role` - we only need to modify the action in `AddRoleButton.tsx`
- [ ] user clicks on `[onboarding] edit guild` - we only need to modify the action in `EditGuildButton.tsx`
- [ ] user clicks on `send discord join button`
- [ ] user picks a channel
- [ ] user modifies the discord embed title
- [ ] user modifies the discord embed description
- [ ] user modifies the discord join button
- [ ] user clicks on `send` (inside the discord join panel customization modal)

### /create-guild/telegram view

Most of these actions are already active, but we should double check them!

- [ ] user clicks on `add guild.xyz bot` button
- [ ] group id paste
- [ ] user picks a logic for the guild
- [ ] adding requirement(s)
- [ ] click on `summon`
- [ ] success/error message

### Before merge

- [ ] Make sure to delete the unused actions from our github gist and source code

Closes #347 