### PR TITLE
Method based authentication

### DIFF
--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -79,15 +79,16 @@ const useSubmitWithSign = <DataType, ResponseType>(
   }: Options<ResponseType> & { message?: string } = { message: DEFAULT_MESSAGE }
 ) => {
   const { account, provider, chainId, connector } = useWeb3React()
-  const [{ peerMeta }] = useLocalStorage<Partial<WalletConnectConnectionData>>(
-    "walletconnect",
-    {}
-  )
+  const [
+    {
+      peerMeta: { name, url },
+    },
+  ] = useLocalStorage<Partial<WalletConnectConnectionData>>("walletconnect", {
+    peerMeta: { name: "", url: "", description: "", icons: [] },
+  })
 
   const isWalletConnect = connector instanceof WalletConnect
-  const isAmbireWallet = [peerMeta?.name, peerMeta?.url].every((str) =>
-    /ambire/i.test(str)
-  )
+  const isAmbireWallet = [name, url].every((str) => /ambire/i.test(str))
   const isAmbireMethod = isWalletConnect && isAmbireWallet
 
   const method =

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -142,7 +142,9 @@ const sign = async ({
   const sig = await provider
     .getSigner(address.toLowerCase())
     .signMessage(
-      `${msg}\n\nAddress: ${addr}\nMethod: ${method}\nChainId: ${chainId}\nHash: ${hash}\nNonce: ${nonce}\nTimestamp: ${ts}`
+      `${msg}\n\nAddress: ${addr}\nMethod: ${method}\nChainId: ${chainId}${
+        hash.length > 0 ? `\nHash: ${hash}` : ""
+      }\nNonce: ${nonce}\nTimestamp: ${ts}`
     )
 
   return {

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -88,10 +88,11 @@ const useSubmitWithSign = <DataType, ResponseType>(
   })
 
   const isWalletConnect = connector instanceof WalletConnect
-  const isMethod3Wallet = [name, url].every((str) => /(ambire)|(gnosis)/i.test(str))
-  const isMethod3 = isWalletConnect && isMethod3Wallet
+  const isAmbireWallet = [name, url].every((str) => /ambire/i.test(str))
+  const isAmbireMethod = isWalletConnect && isAmbireWallet
 
-  const method = (isMethod3 && ValidationMethod.AMBIRE) || ValidationMethod.STANDARD
+  const method =
+    (isAmbireMethod && ValidationMethod.AMBIRE) || ValidationMethod.STANDARD
 
   const [isSigning, setIsSigning] = useState<boolean>(false)
 

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -74,7 +74,7 @@ type ValidationMethod = typeof validationMethods
 export type Validation = {
   params: {
     method: keyof ValidationMethod
-    address: string
+    addr: string
     nonce: string
     hash?: string
     msg: string
@@ -158,7 +158,7 @@ const sign = async ({
       chainId,
       msg,
       method,
-      address: address.toLowerCase(),
+      addr: address.toLowerCase(),
       nonce,
       ...(hash.length > 0 ? { hash } : {}),
       ts,

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -88,11 +88,10 @@ const useSubmitWithSign = <DataType, ResponseType>(
   })
 
   const isWalletConnect = connector instanceof WalletConnect
-  const isAmbireWallet = [name, url].every((str) => /ambire/i.test(str))
-  const isAmbireMethod = isWalletConnect && isAmbireWallet
+  const isMethod3Wallet = [name, url].every((str) => /(ambire)|(gnosis)/i.test(str))
+  const isMethod3 = isWalletConnect && isMethod3Wallet
 
-  const method =
-    (isAmbireMethod && ValidationMethod.AMBIRE) || ValidationMethod.STANDARD
+  const method = (isMethod3 && ValidationMethod.AMBIRE) || ValidationMethod.STANDARD
 
   const [isSigning, setIsSigning] = useState<boolean>(false)
 

--- a/src/hooks/useSubmit.ts
+++ b/src/hooks/useSubmit.ts
@@ -2,9 +2,12 @@ import { keccak256 } from "@ethersproject/keccak256"
 import type { Web3Provider } from "@ethersproject/providers"
 import { toUtf8Bytes } from "@ethersproject/strings"
 import { useWeb3React } from "@web3-react/core"
+import { WalletConnect } from "@web3-react/walletconnect"
 import { randomBytes } from "crypto"
 import stringify from "fast-json-stable-stringify"
 import { useState } from "react"
+import { WalletConnectConnectionData } from "types"
+import useLocalStorage from "./useLocalStorage"
 
 type Options<ResponseType> = {
   onSuccess?: (response: ResponseType) => void
@@ -47,20 +50,58 @@ export type ValidationData = {
 
 export type WithValidation<D> = { data: D; validation: ValidationData }
 
+const validationMethods = {
+  "1": {
+    key: "secp256k1",
+    wallet: "standard",
+  },
+  "2": {
+    key: "secp521r1",
+    wallet: "browser",
+  },
+  "3": {
+    key: "secp256k1",
+    wallet: "ambire",
+  },
+  "4": {
+    key: "secp256k1",
+    wallet: "gnosis",
+  },
+}
+
+type ValidationMethod = typeof validationMethods
+
 export type Validation = {
-  address: string
-  addressSignedMessage: string
-  nonce: string
-  random: string
-  hash?: string
-  timestamp: string
+  params: {
+    method: keyof ValidationMethod
+    address: string
+    nonce: string
+    hash?: string
+    msg: string
+    chainId: string
+    ts: string
+  }
+  sig: string
 }
 
 const useSubmitWithSign = <DataType, ResponseType>(
   fetch: ({ data: DataType, validation: Validation }) => Promise<ResponseType>,
   options: Options<ResponseType> = {}
 ) => {
-  const { account, provider } = useWeb3React()
+  const { account, provider, chainId, connector } = useWeb3React()
+  const [{ peerMeta }] = useLocalStorage<Partial<WalletConnectConnectionData>>(
+    "walletconnect",
+    {}
+  )
+
+  const isWalletConnect = connector instanceof WalletConnect
+  const isAmbireWallet = [peerMeta?.name, peerMeta?.url].every((str) =>
+    /ambire/i.test(str)
+  )
+  const isAmbireMethod = isWalletConnect && isAmbireWallet
+
+  const method = (isAmbireMethod && "3") || "1"
+
   const [isSigning, setIsSigning] = useState<boolean>(false)
 
   const useSubmitResponse = useSubmit<DataType, ResponseType>(
@@ -70,6 +111,8 @@ const useSubmitWithSign = <DataType, ResponseType>(
         provider,
         address: account,
         payload: data ?? {},
+        chainId: chainId.toString(),
+        method,
       }).finally(() => setIsSigning(false))
 
       return fetch({ data: data as DataType, validation })
@@ -80,37 +123,47 @@ const useSubmitWithSign = <DataType, ResponseType>(
   return { ...useSubmitResponse, isSigning }
 }
 
+type SignProps = {
+  provider: Web3Provider
+  address: string
+  payload: any
+  chainId: string
+  method: keyof ValidationMethod
+}
+
 const sign = async ({
   provider,
   address,
   payload,
-}: {
-  provider: Web3Provider
-  address: string
-  payload: any
-}): Promise<Validation> => {
-  const random = randomBytes(32).toString("base64")
-  const nonce = keccak256(toUtf8Bytes(`${address.toLowerCase()}${random}`))
+  chainId,
+  method,
+}: SignProps): Promise<Validation> => {
+  const addr = address.toLowerCase()
+  const nonce = randomBytes(32).toString("base64")
 
   const hash =
     Object.keys(payload).length > 0 ? keccak256(toUtf8Bytes(stringify(payload))) : ""
-  const timestamp = new Date().getTime().toString()
+  const ts = new Date().getTime().toString()
 
-  const addressSignedMessage = await provider
+  const msg = "Please sign this message"
+
+  const sig = await provider
     .getSigner(address.toLowerCase())
     .signMessage(
-      `Please sign this message to verify your request!\nNonce: ${nonce}\nRandom: ${random}\n${
-        hash ? `Hash: ${hash}\n` : ""
-      }Timestamp: ${timestamp}`
+      `${msg}\n\nAddress: ${addr}\nMethod: ${method}\nChainId: ${chainId}\nHash: ${hash}\nNonce: ${nonce}\nTimestamp: ${ts}`
     )
 
   return {
-    address: address.toLowerCase(),
-    addressSignedMessage,
-    nonce,
-    random,
-    ...(hash.length > 0 ? { hash } : {}),
-    timestamp,
+    params: {
+      chainId,
+      msg,
+      method,
+      address: address.toLowerCase(),
+      nonce,
+      ...(hash.length > 0 ? { hash } : {}),
+      ts,
+    },
+    sig,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,7 +321,31 @@ type CreatedPoapData = {
   event_host_id?: number
 }
 
+type WalletConnectConnectionData = {
+  connected: boolean
+  accounts: string[]
+  chainId: number
+  bridge: string
+  key: string
+  clientId: string
+  clientMeta: {
+    description: string
+    url: string
+    icons: string[]
+    name: string
+  }
+  peerId: string
+  peerMeta: {
+    description: string
+    url: string
+    icons: string[]
+    name: string
+  }
+  handshakeId: number
+  handshakeTopic: string
+}
 export type {
+  WalletConnectConnectionData,
   DiscordServerData,
   GuildAdmin,
   Token,

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,6 +1,6 @@
 const fetcher = async (
   resource: string,
-  { body, validation, ...init }: Record<string, any> = {}
+  { body, validation = {}, ...init }: Record<string, any> = {}
 ) => {
   const api =
     !resource.startsWith("http") && !resource.startsWith("/api")
@@ -17,7 +17,7 @@ const fetcher = async (
             validation
               ? {
                   payload,
-                  ...(validation ? { validation } : {}),
+                  ...validation,
                 }
               : body
           ),

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -17,7 +17,7 @@ const fetcher = async (
             validation
               ? {
                   payload,
-                  ...(validation ? { validation } : {}),
+                  ...validation,
                 }
               : body
           ),

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,6 +1,6 @@
 const fetcher = async (
   resource: string,
-  { body, validation = {}, ...init }: Record<string, any> = {}
+  { body, validation, ...init }: Record<string, any> = {}
 ) => {
   const api =
     !resource.startsWith("http") && !resource.startsWith("/api")
@@ -17,7 +17,7 @@ const fetcher = async (
             validation
               ? {
                   payload,
-                  ...validation,
+                  ...(validation ? { validation } : {}),
                 }
               : body
           ),


### PR DESCRIPTION
Closes #390 

Adds support for signatures with Ambire wallet.

With this method we have the possibility to display custom message in the sign request. Right now it just displays the same one everywhere, but this can easily be changes by specifying `message` in the hook call