### PR TITLE
Status update when membership and accessCheck has differences

### DIFF
--- a/src/components/[guild]/hooks/useAutoStatusUpdate.ts
+++ b/src/components/[guild]/hooks/useAutoStatusUpdate.ts
@@ -1,0 +1,45 @@
+import { useWeb3React } from "@web3-react/core"
+import useMemberships from "components/explorer/hooks/useMemberships"
+import { useEffect } from "react"
+import { mutate as swrMutate } from "swr"
+import fetcher from "utils/fetcher"
+import useAccess from "../RolesByPlatform/hooks/useAccess"
+import useGuild from "./useGuild"
+
+const useAutoStatusUpdate = () => {
+  const { id } = useGuild()
+  const { data: roleAccesses } = useAccess()
+  const memberships = useMemberships()
+  const roleMemberships = memberships?.find(
+    (membership) => membership.guildId === id
+  )?.roleIds
+
+  const { account } = useWeb3React()
+
+  useEffect(() => {
+    if (!account || !Array.isArray(roleAccesses) || !Array.isArray(roleMemberships))
+      return
+
+    const roleMembershipsSet = new Set(roleMemberships)
+
+    const accessedRoleIds = roleAccesses
+      .filter(({ access }) => !!access)
+      .map(({ roleId }) => roleId)
+
+    const isMemberInEveryAccessedRole =
+      accessedRoleIds.every((accessedRoleId) =>
+        roleMembershipsSet.has(accessedRoleId)
+      ) && roleMemberships.every((roleId) => accessedRoleIds.includes(roleId))
+
+    if (!isMemberInEveryAccessedRole) {
+      fetcher(`/user/${account}/statusUpdate/${id}`).then(() =>
+        Promise.all([
+          swrMutate(`/guild/access/${id}/${account}`),
+          swrMutate(`/user/membership/${account}`),
+        ])
+      )
+    }
+  }, [roleAccesses, roleMemberships, account, id])
+}
+
+export default useAutoStatusUpdate

--- a/src/pages/[guild]/index.tsx
+++ b/src/pages/[guild]/index.tsx
@@ -64,9 +64,10 @@ const GuildPage = (): JSX.Element => {
       .filter(({ access }) => !!access)
       .map(({ roleId }) => roleId)
 
-    const isMemberInEveryAccessedRole = accessedRoleIds.every((accessedRoleId) =>
-      roleMembershipsSet.has(accessedRoleId)
-    )
+    const isMemberInEveryAccessedRole =
+      accessedRoleIds.every((accessedRoleId) =>
+        roleMembershipsSet.has(accessedRoleId)
+      ) && roleMemberships.every((roleId) => accessedRoleIds.includes(roleId))
 
     if (!isMemberInEveryAccessedRole) {
       fetcher(`/user/${account}/statusUpdate/${id}`).then(() =>

--- a/src/pages/[guild]/index.tsx
+++ b/src/pages/[guild]/index.tsx
@@ -69,7 +69,7 @@ const GuildPage = (): JSX.Element => {
     )
 
     if (!isMemberInEveryAccessedRole) {
-      fetcher(`/user/${account}/statusUpdate`).then(() =>
+      fetcher(`/user/${account}/statusUpdate/${id}`).then(() =>
         Promise.all([
           swrMutate(`/guild/access/${id}/${account}`),
           swrMutate(`/user/membership/${account}`),


### PR DESCRIPTION
Update the user status on focus, when their membership is differs from the current access check.