### PR TITLE
Update Unlock API

### DIFF
--- a/src/components/create-guild/Requirements/components/UnlockFormCard/hooks/useLocks.ts
+++ b/src/components/create-guild/Requirements/components/UnlockFormCard/hooks/useLocks.ts
@@ -3,12 +3,15 @@ import useSWRImmutable from "swr/immutable"
 import fetcher from "utils/fetcher"
 
 const CHAINS_ENDPOINTS = {
-  1: "unlock",
-  100: "xdai",
-  56: "bsc",
-  137: "polygon",
+  1: "mainnet",
+  5: "goerli",
   10: "optimism",
+  56: "bsc",
+  100: "gnosis",
+  137: "polygon",
+  42161: "arbitrum",
   42220: "celo",
+  43114: "avalanche",
 }
 
 type Data = {
@@ -60,7 +63,7 @@ const useLocks = (chain: Chain) => {
 
   const { isValidating, data } = useSWRImmutable<Data[]>(
     chainId
-      ? `https://api.thegraph.com/subgraphs/name/unlock-protocol/${CHAINS_ENDPOINTS[chainId]}`
+      ? `https://api.thegraph.com/subgraphs/name/unlock-protocol/${CHAINS_ENDPOINTS[chainId]}-v2`
       : null,
     fetchLocks
   )


### PR DESCRIPTION
This PR is meant to fix the behavior on the Unlock integration.

Previous Unlock subgraph integration was deprecated as per the documentation: https://docs.unlock-protocol.com/tools/subgraph/

Here we:
- Add some relevant networks
- Update the subgraphs endpoints