### PR TITLE
Update Sismo requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,19 @@ Open source interface for Guild.xyz -- a tool for platformless membership manage
 ### Running the interface locally:
 
 1. `npm i`
-1. `npm run dev`
+2. `npm run dev`
 
 Open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
+
+#### For Windows users
+
+If you encounter the error `ERR_OSSL_EVP_UNSUPPORTED` you can do :
+
+```bash
+export NODE_OPTIONS=--openssl-legacy-provider
+npm i --force
+npm run dev
+```
 
 ### Getting secret environment variables (for core team members):
 

--- a/src/requirements/Sismo/SismoForm.tsx
+++ b/src/requirements/Sismo/SismoForm.tsx
@@ -76,7 +76,7 @@ const SismoForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => {
               ref={ref}
               options={typeOptions}
               value={typeOptions?.find((option) => option.value === value) ?? ""}
-              placeholder="Select environment"
+              placeholder="Select network"
               onChange={(newSelectedOption: SelectOption) => {
                 setValue(`${baseFieldPath}.data.id`, null)
                 onChange(newSelectedOption?.value)

--- a/src/requirements/Sismo/SismoForm.tsx
+++ b/src/requirements/Sismo/SismoForm.tsx
@@ -21,10 +21,6 @@ const typeOptions: { label: string; value: SismoBadgeType }[] = [
     value: "GNOSIS",
   },
   {
-    label: "Mainnet",
-    value: "MAINNET",
-  },
-  {
     label: "Polygon",
     value: "POLYGON",
   },

--- a/src/requirements/Sismo/SismoForm.tsx
+++ b/src/requirements/Sismo/SismoForm.tsx
@@ -65,7 +65,7 @@ const SismoForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => {
         isRequired
         isInvalid={!!parseFromObject(errors, baseFieldPath)?.data?.type}
       >
-        <FormLabel>Environment</FormLabel>
+        <FormLabel>Network</FormLabel>
 
         <Controller
           name={`${baseFieldPath}.data.type` as const}

--- a/src/requirements/Sismo/SismoForm.tsx
+++ b/src/requirements/Sismo/SismoForm.tsx
@@ -13,15 +13,31 @@ import { Controller, useFormContext, useWatch } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
 import { SelectOption } from "types"
 import parseFromObject from "utils/parseFromObject"
-import useSismoBadges from "./hooks/useSismoBadges"
+import useSismoBadges, { SismoBadgeType } from "./hooks/useSismoBadges"
 
-const typeOptions = [
+const typeOptions: { label: string; value: SismoBadgeType }[] = [
   {
-    label: "Main",
-    value: "MAIN",
+    label: "Gnosis",
+    value: "GNOSIS",
   },
   {
-    label: "Playground",
+    label: "Mainnet",
+    value: "MAINNET",
+  },
+  {
+    label: "Polygon",
+    value: "POLYGON",
+  },
+  {
+    label: "Goerli",
+    value: "GOERLI",
+  },
+  {
+    label: "Mumbai",
+    value: "MUMBAI",
+  },
+  {
+    label: "Playground (deprecated)",
     value: "PLAYGROUND",
   },
 ]

--- a/src/requirements/Sismo/hooks/useSismoBadges.ts
+++ b/src/requirements/Sismo/hooks/useSismoBadges.ts
@@ -5,7 +5,6 @@ export type SismoBadgeType = keyof typeof apiUrl
 
 const apiUrl = {
   GNOSIS: "https://hub.sismo.io/badges/gnosis",
-  MAINNET: "https://hub.sismo.io/badges/mainnet",
   POLYGON: "https://hub.sismo.io/badges/polygon",
   GOERLI: "https://hub.testnets.sismo.io/badges/goerli",
   MUMBAI: "https://hub.testnets.sismo.io/badges/mumbai",

--- a/src/requirements/Sismo/hooks/useSismoBadges.ts
+++ b/src/requirements/Sismo/hooks/useSismoBadges.ts
@@ -1,10 +1,14 @@
 import useSWRImmutable from "swr/immutable"
 import fetcher from "utils/fetcher"
 
-type SismoBadgeType = "MAIN" | "PLAYGROUND"
+export type SismoBadgeType = keyof typeof apiUrl
 
-const apiUrl: Record<SismoBadgeType, string> = {
-  MAIN: "https://hub.sismo.io/badges/polygon",
+const apiUrl = {
+  GNOSIS: "https://hub.sismo.io/badges/gnosis",
+  MAINNET: "https://hub.sismo.io/badges/mainnet",
+  POLYGON: "https://hub.sismo.io/badges/polygon",
+  GOERLI: "https://hub.testnets.sismo.io/badges/goerli",
+  MUMBAI: "https://hub.testnets.sismo.io/badges/mumbai",
   PLAYGROUND: "https://hub.playground.sismo.io/badges/polygon",
 }
 


### PR DESCRIPTION
Sismo updated the endpoints to query the badges from. This PR update these endpoints.

The addresses of the contracts must also be updated to get the balance: 
- Polygon: 0xF12494e3545D49616D9dFb78E5907E9078618a34
- Gnosis: 0xa67f1c6c96cb5dd6ef24b07a77893693c210d846
- Goerli: 0xA251eb9Be4e7E2bb382268eCdd0a5fca0A962E6c
- Mumbai: 0xc3Ee5Aad6Fb987cF69a2EE7B3B2c92E21E42F34B

_Note: I also updated the document in the README as I encountered some issue installing the app on windows (#643)_

![image](https://user-images.githubusercontent.com/8143464/212107551-34fe8857-1a51-4777-bda1-ebd31d63a39a.png)

