### PR TITLE
Hotfix member count at discord role creation

### DIFF
--- a/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/DiscordCardSettings/components/RoleToManage/components/GuildifyExistingRole.tsx
+++ b/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/DiscordCardSettings/components/RoleToManage/components/GuildifyExistingRole.tsx
@@ -21,7 +21,7 @@ const GuildifyExistingRole = () => {
   const { guildPlatform, index } = useRolePlatform()
   const {
     data: { roles: discordRoles },
-  } = useServerData(guildPlatform.platformGuildId)
+  } = useServerData(guildPlatform.platformGuildId, true)
 
   const options = useMemo(() => {
     if (!discordRoles || !guildRoles) return undefined

--- a/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/DiscordCardSettings/components/RoleToManage/components/GuildifyExistingRole.tsx
+++ b/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/DiscordCardSettings/components/RoleToManage/components/GuildifyExistingRole.tsx
@@ -21,7 +21,7 @@ const GuildifyExistingRole = () => {
   const { guildPlatform, index } = useRolePlatform()
   const {
     data: { roles: discordRoles },
-  } = useServerData(guildPlatform.platformGuildId, true)
+  } = useServerData(guildPlatform.platformGuildId, { memberCountDetails: true })
 
   const options = useMemo(() => {
     if (!discordRoles || !guildRoles) return undefined

--- a/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/useDiscordCardProps.tsx
+++ b/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/useDiscordCardProps.tsx
@@ -5,7 +5,7 @@ import { useRolePlatform } from "../../../RolePlatformProvider"
 
 const useDiscordCardProps = (guildPlatform: GuildPlatform) => {
   const rolePlatform = useRolePlatform()
-  const { data } = useServerData(guildPlatform.platformGuildId, {
+  const { data } = useServerData(guildPlatform.platformGuildId, false, {
     revalidateOnFocus: false,
   })
 

--- a/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/useDiscordCardProps.tsx
+++ b/src/components/[guild]/RolePlatforms/components/PlatformCard/components/useDiscordCardProps/useDiscordCardProps.tsx
@@ -5,8 +5,10 @@ import { useRolePlatform } from "../../../RolePlatformProvider"
 
 const useDiscordCardProps = (guildPlatform: GuildPlatform) => {
   const rolePlatform = useRolePlatform()
-  const { data } = useServerData(guildPlatform.platformGuildId, false, {
-    revalidateOnFocus: false,
+  const { data } = useServerData(guildPlatform.platformGuildId, {
+    swrOptions: {
+      revalidateOnFocus: false,
+    },
   })
 
   const roleName = useMemo(() => {

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -27,7 +27,7 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
 
   const {
     data: { isAdmin, channels },
-  } = useServerData(serverData.id, {
+  } = useServerData(serverData.id, false, {
     refreshInterval: !!activeAddBotPopup ? 2000 : 0,
     refreshWhenHidden: true,
   })

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -27,9 +27,11 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
 
   const {
     data: { isAdmin, channels },
-  } = useServerData(serverData.id, false, {
-    refreshInterval: !!activeAddBotPopup ? 2000 : 0,
-    refreshWhenHidden: true,
+  } = useServerData(serverData.id, {
+    swrOptions: {
+      refreshInterval: !!activeAddBotPopup ? 2000 : 0,
+      refreshWhenHidden: true,
+    },
   })
 
   const prevActiveAddBotPopup = usePrevious(activeAddBotPopup)

--- a/src/components/common/DiscordGuildSetup/components/ServerSetupCard/ServerSetupCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/ServerSetupCard/ServerSetupCard.tsx
@@ -19,8 +19,10 @@ const ServerSetupCard = ({ selectedServer, onSubmit }: Props): JSX.Element => {
 
   const {
     data: { serverIcon, serverName },
-  } = useServerData(selectedServer, false, {
-    refreshInterval: 0,
+  } = useServerData(selectedServer, {
+    swrOptions: {
+      refreshInterval: 0,
+    },
   })
 
   const { onUpload } = usePinata({

--- a/src/components/common/DiscordGuildSetup/components/ServerSetupCard/ServerSetupCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/ServerSetupCard/ServerSetupCard.tsx
@@ -19,7 +19,7 @@ const ServerSetupCard = ({ selectedServer, onSubmit }: Props): JSX.Element => {
 
   const {
     data: { serverIcon, serverName },
-  } = useServerData(selectedServer, {
+  } = useServerData(selectedServer, false, {
     refreshInterval: 0,
   })
 

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -27,7 +27,6 @@ export type Role = {
 
 type ServerData = {
   serverIcon: string
-  membersWithoutRole: number
   serverName: string
   serverId: string
   categories: Category[]
@@ -38,7 +37,6 @@ type ServerData = {
 
 const fallbackData = {
   serverIcon: null,
-  membersWithoutRole: 0,
   serverName: "",
   serverId: "",
   categories: [],

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -45,11 +45,16 @@ const fallbackData = {
   roles: [],
 }
 
-const useServerData = (serverId: string, swrOptions?: SWRConfiguration) => {
+const useServerData = (
+  serverId: string,
+  memberCountDetails: boolean = false,
+  swrOptions?: SWRConfiguration
+) => {
   const shouldFetch = serverId?.length >= 0
-
   const { data, isValidating, error, mutate } = useSWR<ServerData>(
-    shouldFetch ? [`/discord/server/${serverId}`, { method: "POST" }] : null,
+    shouldFetch
+      ? [`/discord/server/${serverId}/${memberCountDetails}`, { method: "POST" }]
+      : null,
     {
       fallbackData,
       revalidateOnFocus: false,

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -57,7 +57,7 @@ const useServerData = (
     shouldFetch
       ? [
           `/discord/server/${serverId}/${option?.memberCountDetails}`,
-          { method: "POST" },
+          { method: "GET" },
         ]
       : null,
     {

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -47,18 +47,23 @@ const fallbackData = {
 
 const useServerData = (
   serverId: string,
-  memberCountDetails: boolean = false,
-  swrOptions?: SWRConfiguration
+  option?: {
+    memberCountDetails?: boolean
+    swrOptions?: SWRConfiguration
+  }
 ) => {
   const shouldFetch = serverId?.length >= 0
   const { data, isValidating, error, mutate } = useSWR<ServerData>(
     shouldFetch
-      ? [`/discord/server/${serverId}/${memberCountDetails}`, { method: "POST" }]
+      ? [
+          `/discord/server/${serverId}/${option?.memberCountDetails}`,
+          { method: "POST" },
+        ]
       : null,
     {
       fallbackData,
       revalidateOnFocus: false,
-      ...swrOptions,
+      ...option?.swrOptions,
     }
   )
 


### PR DESCRIPTION
Refactored the `useServerData` hook for the guildify component.

Removed `membersWithoutRole` property, because as far as I checked, we don't use.