### PR TITLE
Posthog events for Twitter connection

### DIFF
--- a/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
+++ b/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
@@ -3,6 +3,7 @@ import useUser from "components/[guild]/hooks/useUser"
 import useDatadog from "components/_app/Datadog/useDatadog"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
+import { usePostHog } from "posthog-js/react"
 import { useEffect } from "react"
 import { PlatformName } from "types"
 import fetcher from "utils/fetcher"
@@ -33,7 +34,11 @@ const useConnectPlatform = (
     platformAuthHooks[platform]?.() ?? {}
   const prevAuthData = usePrevious(authData)
 
-  const { onSubmit, isLoading, response } = useConnect(onSuccess)
+  const posthog = usePostHog()
+  const { onSubmit, isLoading, response } = useConnect(() => {
+    onSuccess?.()
+    posthog.capture("Platform connection", { platform, isReauth })
+  })
 
   useEffect(() => {
     // couldn't prevent spamming requests without all these three conditions

--- a/src/components/[guild]/hooks/useAccess.ts
+++ b/src/components/[guild]/hooks/useAccess.ts
@@ -1,6 +1,7 @@
 import { useWeb3React } from "@web3-react/core"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
+import { usePostHog } from "posthog-js/react"
 import { SWRConfiguration } from "swr"
 
 const useAccess = (roleId?: number, swrOptions?: SWRConfiguration) => {
@@ -8,10 +9,42 @@ const useAccess = (roleId?: number, swrOptions?: SWRConfiguration) => {
   const { id } = useGuild()
 
   const shouldFetch = account && id && roleId !== 0
+  const posthog = usePostHog()
 
   const { data, error, isValidating, mutate } = useSWRWithOptionalAuth(
     shouldFetch ? `/guild/access/${id}/${account}` : null,
-    { shouldRetryOnError: false, ...swrOptions }
+    {
+      shouldRetryOnError: false,
+      onSuccess: (accessCheckResult: any) => {
+        const twitterNotConneted = accessCheckResult.some(({ errors }) =>
+          errors?.some(
+            ({ subType, errorType }) =>
+              subType.toUpperCase() === "TWITTER" &&
+              errorType === "PLATFORM_NOT_CONNECTED"
+          )
+        )
+
+        const twitterNeedsToBeReconnected = accessCheckResult.some(({ errors }) =>
+          errors?.some(
+            ({ subType, errorType }) =>
+              subType.toUpperCase() === "TWITTER" &&
+              errorType === "PLATFORM_CONNECT_INVALID"
+          )
+        )
+
+        const eventProps: any = { accessCheckResult }
+        if (twitterNotConneted) {
+          eventProps.twitterNotConneted = true
+        }
+
+        if (twitterNeedsToBeReconnected) {
+          eventProps.twitterNeedsToBeReconnected = true
+        }
+
+        posthog.capture("Access check", eventProps)
+      },
+      ...swrOptions,
+    }
   )
 
   const roleData = roleId && data?.find?.((role) => role.roleId === roleId)

--- a/src/components/[guild]/hooks/useAccess.ts
+++ b/src/components/[guild]/hooks/useAccess.ts
@@ -1,6 +1,7 @@
 import { useWeb3React } from "@web3-react/core"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
+import platforms from "platforms/platforms"
 import { usePostHog } from "posthog-js/react"
 import { SWRConfiguration } from "swr"
 
@@ -16,32 +17,31 @@ const useAccess = (roleId?: number, swrOptions?: SWRConfiguration) => {
     {
       shouldRetryOnError: false,
       onSuccess: (accessCheckResult: any) => {
-        const twitterNotConneted = accessCheckResult.some(({ errors }) =>
-          errors?.some(
-            ({ subType, errorType }) =>
-              subType.toUpperCase() === "TWITTER" &&
-              errorType === "PLATFORM_NOT_CONNECTED"
+        const unconnectedPlatforms = Object.keys(platforms).filter((platform) =>
+          accessCheckResult.some(({ errors }) =>
+            errors?.some(
+              ({ subType, errorType }) =>
+                subType.toUpperCase() === platform &&
+                errorType === "PLATFORM_NOT_CONNECTED"
+            )
           )
         )
 
-        const twitterNeedsToBeReconnected = accessCheckResult.some(({ errors }) =>
-          errors?.some(
-            ({ subType, errorType }) =>
-              subType.toUpperCase() === "TWITTER" &&
-              errorType === "PLATFORM_CONNECT_INVALID"
+        const platformsToReconnect = Object.keys(platforms).filter((platform) =>
+          accessCheckResult.some(({ errors }) =>
+            errors?.some(
+              ({ subType, errorType }) =>
+                subType.toUpperCase() === platform &&
+                errorType === "PLATFORM_CONNECT_INVALID"
+            )
           )
         )
 
-        const eventProps: any = { accessCheckResult }
-        if (twitterNotConneted) {
-          eventProps.twitterNotConneted = true
-        }
-
-        if (twitterNeedsToBeReconnected) {
-          eventProps.twitterNeedsToBeReconnected = true
-        }
-
-        posthog.capture("Access check", eventProps)
+        posthog.capture("Access check", {
+          accessCheckResult,
+          unconnectedPlatforms,
+          platformsToReconnect,
+        })
       },
       ...swrOptions,
     }

--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -2,7 +2,6 @@ import { useDisclosure } from "@chakra-ui/react"
 import { CoinbaseWallet } from "@web3-react/coinbase-wallet"
 import { useWeb3React } from "@web3-react/core"
 import { WalletConnect } from "@web3-react/walletconnect"
-import AccountModal from "components/common/Layout/components/Account/components/AccountModal"
 import NetworkModal from "components/common/Layout/components/Account/components/NetworkModal/NetworkModal"
 import requestNetworkChangeHandler from "components/common/Layout/components/Account/components/NetworkModal/utils/requestNetworkChange"
 import { Chains, RPC } from "connectors"
@@ -10,8 +9,8 @@ import useContractWalletInfoToast from "hooks/useContractWalletInfoToast"
 import useToast from "hooks/useToast"
 import { useRouter } from "next/router"
 import {
-  createContext,
   PropsWithChildren,
+  createContext,
   useContext,
   useEffect,
   useState,
@@ -128,7 +127,6 @@ const Web3ConnectionManager = ({
         onClose={closeWalletSelectorModal}
       />
       <NetworkModal isOpen={isNetworkModalOpen} onClose={closeNetworkModal} />
-      <AccountModal isOpen={isAccountModalOpen} onClose={closeAccountModal} />
     </Web3Connection.Provider>
   )
 }

--- a/src/components/common/Layout/components/Account/components/AccountModal/AccountModal.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/AccountModal.tsx
@@ -16,20 +16,24 @@ import { CoinbaseWallet } from "@web3-react/coinbase-wallet"
 import { useWeb3React } from "@web3-react/core"
 import { MetaMask } from "@web3-react/metamask"
 import { WalletConnect } from "@web3-react/walletconnect"
+import useUser from "components/[guild]/hooks/useUser"
+import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import CopyableAddress from "components/common/CopyableAddress"
 import GuildAvatar from "components/common/GuildAvatar"
 import { Modal } from "components/common/Modal"
-import useUser from "components/[guild]/hooks/useUser"
-import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import useResolveAddress from "hooks/resolving/useResolveAddress"
 import { deleteKeyPairFromIdb } from "hooks/useKeyPair"
 import { SignOut } from "phosphor-react"
 import AccountConnections from "./components/AccountConnections"
 import PrimaryAddressTag from "./components/PrimaryAddressTag"
 
-const AccountModal = ({ isOpen, onClose }) => {
+const AccountModal = () => {
   const { account, connector } = useWeb3React()
-  const { setIsDelegateConnection } = useWeb3ConnectionManager()
+  const {
+    setIsDelegateConnection,
+    isAccountModalOpen: isOpen,
+    closeAccountModal: onClose,
+  } = useWeb3ConnectionManager()
   const { id, addresses } = useUser()
 
   const connectorName = (c) =>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import ExplorerProvider from "components/_app/ExplorerProvider"
 import IntercomProvider from "components/_app/IntercomProvider"
 import PostHogProvider from "components/_app/PostHogProvider"
 import { Web3ConnectionManager } from "components/_app/Web3ConnectionManager"
+import AccountModal from "components/common/Layout/components/Account/components/AccountModal"
 import { connectors } from "connectors"
 import type { AppProps } from "next/app"
 import { useRouter } from "next/router"
@@ -84,6 +85,7 @@ const App = ({
                     <IntercomProvider>
                       <ExplorerProvider>
                         <Component {...pageProps} />
+                        <AccountModal />
                       </ExplorerProvider>
                     </IntercomProvider>
                   </PostHogProvider>


### PR DESCRIPTION
I couldn't write a HogQL query for the entire access check result, so I've added some extra arrays (`unconnectedPlatforms` and `platformsToReconnect`). I couldn't make a common funnel for all the platforms, as it would need different filters for the different platforms, and I couldn't find an option to do that. I think it's fine for now, as we mostly care about Twitter now
I had to move the `AccountModal` from `Web3ConnectionManger` to a more inner scope, so it can consume PostHogProvider. I could't move `PostHogProvider` to upper scope, since it also needs to consume `Web3ConnectionManger`