### PR TITLE
feat: Save non-purchasable assets to Vercel KV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@notionhq/client": "^2.2.2",
         "@nouns/assets": "^0.4.2",
         "@snyk/protect": "latest",
+        "@vercel/kv": "^0.2.1",
         "@vercel/og": "^0.5.0",
         "@web3-react/coinbase-wallet": "^8.2.0",
         "@web3-react/core": "^8.2.0",
@@ -6709,6 +6710,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.20.6.tgz",
+      "integrity": "sha512-q1izaYEUsq/WiXNOjf4oOjFZe8fIeBSZN8d5cEyOD4nem+zxc4jccieorQQrNlEahKPE1ZYLzVEkMODRUfch2g==",
+      "dependencies": {
+        "isomorphic-fetch": "^3.0.0"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-0.2.1.tgz",
+      "integrity": "sha512-0O1CVh0maG/bduAE6DPKUTfGSnORgrcS5xBYZCb62sOU7PrVZrXhaPbUSBE4q5PXS5DC+cpN6FY2RWNlslUaWQ==",
+      "dependencies": {
+        "@upstash/redis": "1.20.6"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/@vercel/og": {
@@ -14574,6 +14594,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
@@ -22120,6 +22149,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@notionhq/client": "^2.2.2",
     "@nouns/assets": "^0.4.2",
     "@snyk/protect": "latest",
+    "@vercel/kv": "^0.2.1",
     "@vercel/og": "^0.5.0",
     "@web3-react/coinbase-wallet": "^8.2.0",
     "@web3-react/core": "^8.2.0",

--- a/src/components/[guild]/EditGuild/components/FeatureFlags.tsx
+++ b/src/components/[guild]/EditGuild/components/FeatureFlags.tsx
@@ -5,7 +5,6 @@ import { SelectOption } from "types"
 import capitalize from "utils/capitalize"
 
 const FEATURE_FLAGS = [
-  "PURCHASE_REQUIREMENT",
   "PAYMENT_REQUIREMENT",
   "TWITTER_EXTRA_REQUIREMENT",
   "VISIBILITY",

--- a/src/components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement.tsx
@@ -1,0 +1,48 @@
+import useAccess from "components/[guild]/hooks/useAccess"
+import useNonPurchasableAssets from "components/[guild]/hooks/useNonPurchasableAssets"
+import { Chains } from "connectors"
+import dynamic from "next/dynamic"
+import {
+  PURCHASABLE_REQUIREMENT_TYPES,
+  purchaseSupportedChains,
+} from "utils/guildCheckout/constants"
+import { useGuildCheckoutContext } from "./components/GuildCheckoutContex"
+
+const DynamicallyLoadedPurchaseRequirement = dynamic(
+  () => import("./PurchaseRequirement"),
+  {
+    ssr: false,
+  }
+)
+
+const DynamicPurchaseRequirement = () => {
+  const { data } = useNonPurchasableAssets()
+
+  const { requirement, isOpen, isInfoModalOpen } = useGuildCheckoutContext()
+
+  const { data: accessData, isValidating: isAccessValidating } = useAccess(
+    requirement?.roleId
+  )
+  const satisfiesRequirement = accessData?.requirements?.find(
+    (req) => req.requirementId === requirement.id
+  )?.access
+
+  const shouldNotRenderComponent =
+    !isOpen &&
+    !isInfoModalOpen &&
+    ((!accessData && isAccessValidating) ||
+      satisfiesRequirement ||
+      !PURCHASABLE_REQUIREMENT_TYPES.includes(requirement.type) ||
+      !purchaseSupportedChains[requirement.type]?.includes(requirement.chain))
+
+  if (
+    !data ||
+    data[Chains[requirement.chain]]?.includes(requirement.address?.toLowerCase()) ||
+    shouldNotRenderComponent
+  )
+    return null
+
+  return <DynamicallyLoadedPurchaseRequirement />
+}
+
+export default DynamicPurchaseRequirement

--- a/src/components/[guild]/Requirements/components/GuildCheckout/PurchaseRequirement.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/PurchaseRequirement.tsx
@@ -12,48 +12,33 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { useWeb3React } from "@web3-react/core"
-import useAccess from "components/[guild]/hooks/useAccess"
-import useGuild from "components/[guild]/hooks/useGuild"
-import { usePostHogContext } from "components/_app/PostHogProvider"
 import Button from "components/common/Button"
 import { Modal } from "components/common/Modal"
+import useGuild from "components/[guild]/hooks/useGuild"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import { Chains, RPC } from "connectors"
 import { ShoppingCartSimple } from "phosphor-react"
-import {
-  DISABLED_TOKENS,
-  PURCHASABLE_REQUIREMENT_TYPES,
-  purchaseSupportedChains,
-} from "utils/guildCheckout/constants"
 import BlockExplorerUrl from "../BlockExplorerUrl"
 import AlphaTag from "./components/AlphaTag"
-import ErrorCollapse from "./components/ErrorCollapse"
-import { useGuildCheckoutContext } from "./components/GuildCheckoutContex"
-import PaymentCurrencyPicker from "./components/PaymentCurrencyPicker"
-import PaymentMethodButtons from "./components/PaymentMethodButtons"
-import PurchaseFeeAndTotal from "./components/PurchaseFeeAndTotal"
-import PurchasedRequirementInfo from "./components/PurchasedRequirementInfo"
-import TOSCheckbox from "./components/TOSCheckbox"
 import ConnectWalletButton from "./components/buttons/ConnectWalletButton"
 import PurchaseAllowanceButton from "./components/buttons/PurchaseAllowanceButton"
 import PurchaseButton from "./components/buttons/PurchaseButton"
 import SwitchNetworkButton from "./components/buttons/SwitchNetworkButton"
+import ErrorCollapse from "./components/ErrorCollapse"
+import { useGuildCheckoutContext } from "./components/GuildCheckoutContex"
+import PaymentCurrencyPicker from "./components/PaymentCurrencyPicker"
+import PaymentMethodButtons from "./components/PaymentMethodButtons"
+import PurchasedRequirementInfo from "./components/PurchasedRequirementInfo"
+import PurchaseFeeAndTotal from "./components/PurchaseFeeAndTotal"
+import TOSCheckbox from "./components/TOSCheckbox"
 import usePrice from "./hooks/usePrice"
 
 const PurchaseRequirement = (): JSX.Element => {
   const { captureEvent } = usePostHogContext()
 
-  const { featureFlags } = useGuild()
-
   const { account, chainId } = useWeb3React()
-  const { requirement, isOpen, onOpen, onClose, isInfoModalOpen } =
-    useGuildCheckoutContext()
+  const { requirement, isOpen, onOpen, onClose } = useGuildCheckoutContext()
   const { urlName, name } = useGuild()
-  const { data: accessData, isValidating: isAccessValidating } = useAccess(
-    requirement?.roleId
-  )
-  const satisfiesRequirement = accessData?.requirements?.find(
-    (req) => req.requirementId === requirement.id
-  )?.access
 
   const {
     data: { estimatedPriceInUSD },
@@ -67,20 +52,6 @@ const PurchaseRequirement = (): JSX.Element => {
       guild: urlName,
     })
   }
-
-  if (
-    !isOpen &&
-    !isInfoModalOpen &&
-    (!featureFlags.includes("PURCHASE_REQUIREMENT") ||
-      DISABLED_TOKENS[requirement.chain]?.includes(
-        requirement.address?.toLowerCase()
-      ) ||
-      (!accessData && isAccessValidating) ||
-      satisfiesRequirement ||
-      !PURCHASABLE_REQUIREMENT_TYPES.includes(requirement.type) ||
-      !purchaseSupportedChains[requirement.type]?.includes(requirement.chain))
-  )
-    return null
 
   return (
     <>

--- a/src/components/[guild]/hooks/useNonPurchasableAssets.ts
+++ b/src/components/[guild]/hooks/useNonPurchasableAssets.ts
@@ -1,0 +1,18 @@
+import useSWRImmutable from "swr/immutable"
+import { PURCHASABLE_REQUIREMENT_TYPES } from "utils/guildCheckout/constants"
+import useGuild from "./useGuild"
+
+const useNonPurchasableAssets = () => {
+  const { roles } = useGuild()
+  const requirements = roles?.flatMap((role) => role.requirements) ?? []
+
+  const shouldFetch = requirements.some((req) =>
+    PURCHASABLE_REQUIREMENT_TYPES.includes(req.type)
+  )
+
+  return useSWRImmutable<Record<number, string[]>>(
+    shouldFetch ? "/api/nonPurchasableAssets" : null
+  )
+}
+
+export default useNonPurchasableAssets

--- a/src/pages/api/fetchPrice.ts
+++ b/src/pages/api/fetchPrice.ts
@@ -236,7 +236,12 @@ const handler: NextApiHandler<FetchPriceResponse> = async (
     }).toString()
 
     const response = await fetch(
-      `${ZEROX_API_URLS[chain]}/swap/v1/quote?${queryParams}`
+      `${ZEROX_API_URLS[chain]}/swap/v1/quote?${queryParams}`,
+      {
+        headers: {
+          "0x-api-key": process.env.ZEROX_API_KEY,
+        },
+      }
     )
 
     const responseData = await response.json()

--- a/src/pages/api/fetchPrice.ts
+++ b/src/pages/api/fetchPrice.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "@ethersproject/bignumber"
 import { Contract } from "@ethersproject/contracts"
 import { JsonRpcProvider } from "@ethersproject/providers"
 import { formatUnits, parseUnits } from "@ethersproject/units"
+import { kv } from "@vercel/kv"
 import { Chain, Chains, RPC } from "connectors"
 import { NextApiHandler, NextApiRequest, NextApiResponse } from "next"
 import { RequirementType } from "requirements"
@@ -19,6 +20,7 @@ import {
   ZEROX_SUPPORTED_SOURCES,
 } from "utils/guildCheckout/constants"
 import { flipPath } from "utils/guildCheckout/utils"
+import { NON_PURCHASABLE_ASSETS_KV_KEY } from "./nonPurchasableAssets"
 
 export type FetchPriceResponse = {
   buyAmount: number
@@ -240,11 +242,26 @@ const handler: NextApiHandler<FetchPriceResponse> = async (
     const responseData = await response.json()
 
     if (response.status !== 200) {
-      const errorMessage = responseData.validationErrors?.length
-        ? responseData.validationErrors[0].reason === "INSUFFICIENT_ASSET_LIQUIDITY"
-          ? "We are not able to find this token on the market. Contact guild admins for further help."
-          : responseData.validationErrors[0].description
-        : response.statusText
+      let errorMessage = response.statusText
+
+      if (responseData.validationErrors?.length) {
+        if (
+          responseData.validationErrors[0].reason === "INSUFFICIENT_ASSET_LIQUIDITY"
+        ) {
+          // Set error message and save the token address to the KV store, so we won't try to fetch the price for it anymore
+          errorMessage =
+            "We are not able to find this token on the market. Contact guild admins for further help."
+
+          await kv.set(
+            `${NON_PURCHASABLE_ASSETS_KV_KEY}:${
+              Chains[chain]
+            }:${address.toLowerCase()}`,
+            true
+          )
+        } else {
+          errorMessage = responseData.validationErrors[0].description
+        }
+      }
 
       return res.status(response.status).json({
         error: errorMessage,

--- a/src/pages/api/fetchPrice.ts
+++ b/src/pages/api/fetchPrice.ts
@@ -257,11 +257,9 @@ const handler: NextApiHandler<FetchPriceResponse> = async (
           errorMessage =
             "We are not able to find this token on the market. Contact guild admins for further help."
 
-          await kv.set(
-            `${NON_PURCHASABLE_ASSETS_KV_KEY}:${
-              Chains[chain]
-            }:${address.toLowerCase()}`,
-            true
+          await kv.lpush(
+            `${NON_PURCHASABLE_ASSETS_KV_KEY}:${Chains[chain]}`,
+            address.toLowerCase()
           )
         } else {
           errorMessage = responseData.validationErrors[0].description

--- a/src/pages/api/nonPurchasableAssets.ts
+++ b/src/pages/api/nonPurchasableAssets.ts
@@ -1,0 +1,28 @@
+import { kv } from "@vercel/kv"
+import { NextApiRequest, NextApiResponse } from "next"
+
+export const NON_PURCHASABLE_ASSETS_KV_KEY = "nonPurchasableTokens"
+
+const handler = async (request: NextApiRequest, response: NextApiResponse) => {
+  if (request.method !== "GET") {
+    response.setHeader("Allow", "GET, POST")
+    response.status(405).json({ error: `Method ${request.method} is not allowed` })
+    return
+  }
+
+  const nonPurchasableTokens = await kv.keys(`${NON_PURCHASABLE_ASSETS_KV_KEY}:*`)
+
+  const res: Record<number, string[]> = {}
+
+  for (const row of nonPurchasableTokens) {
+    const [, chainId, address] = row.split(":")
+
+    if (!res[chainId]) res[chainId] = []
+
+    res[chainId].push(address)
+  }
+
+  response.status(200).json(res)
+}
+
+export default handler

--- a/src/requirements/Nft/NftRequirement.tsx
+++ b/src/requirements/Nft/NftRequirement.tsx
@@ -4,7 +4,7 @@ import BlockExplorerUrl from "components/[guild]/Requirements/components/BlockEx
 import DataBlock from "components/[guild]/Requirements/components/DataBlock"
 import { GuildCheckoutProvider } from "components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex"
 import PurchaseTransactionStatusModal from "components/[guild]/Requirements/components/GuildCheckout/components/PurchaseTransactionStatusModal"
-import PurchaseRequirement from "components/[guild]/Requirements/components/GuildCheckout/PurchaseRequirement"
+import DynamicPurchaseRequirement from "components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement"
 import Requirement, {
   RequirementProps,
 } from "components/[guild]/Requirements/components/Requirement"
@@ -66,7 +66,7 @@ const NftRequirement = (props: RequirementProps) => {
       footer={
         <HStack spacing={4}>
           <GuildCheckoutProvider>
-            <PurchaseRequirement />
+            <DynamicPurchaseRequirement />
             <PurchaseTransactionStatusModal />
           </GuildCheckoutProvider>
           <BlockExplorerUrl />

--- a/src/requirements/Token/TokenRequirement.tsx
+++ b/src/requirements/Token/TokenRequirement.tsx
@@ -1,8 +1,8 @@
 import { HStack, Text } from "@chakra-ui/react"
 import BlockExplorerUrl from "components/[guild]/Requirements/components/BlockExplorerUrl"
-import PurchaseRequirement from "components/[guild]/Requirements/components/GuildCheckout/PurchaseRequirement"
 import { GuildCheckoutProvider } from "components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex"
 import PurchaseTransactionStatusModal from "components/[guild]/Requirements/components/GuildCheckout/components/PurchaseTransactionStatusModal"
+import DynamicPurchaseRequirement from "components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement"
 import Requirement, {
   RequirementProps,
 } from "components/[guild]/Requirements/components/Requirement"
@@ -39,7 +39,7 @@ const TokenRequirement = ({ setValueForBalancy, ...rest }: Props) => {
         requirement?.type === "ERC20" && (
           <HStack spacing="4">
             <GuildCheckoutProvider>
-              <PurchaseRequirement />
+              <DynamicPurchaseRequirement />
               <PurchaseTransactionStatusModal />
             </GuildCheckoutProvider>
             <BlockExplorerUrl />

--- a/src/utils/guildCheckout/constants.ts
+++ b/src/utils/guildCheckout/constants.ts
@@ -212,46 +212,6 @@ export const getAssetsCallParams: Record<
   },
 }
 
-export const DISABLED_TOKENS: Partial<Record<Chain, string[]>> = {
-  ETHEREUM: [
-    "0x0e42acbd23faee03249daff896b78d7e79fbd58e",
-    "0x5b272ce3e225b019a3fbd968206824b24c674344",
-    "0x87165b659ba7746907a48763063efa3b323c2b07",
-    "0x472d0b0ddfe0bc02c27928b8bcbd67e65d07d48a",
-    "0x250316b3e46600417654b13bea68b5f64d61e609",
-    "0x59c1349bc6f28a427e78ddb6130ec669c2f39b48",
-    "0x742b70151cd3bc7ab598aaff1d54b90c3ebc6027",
-    "0x93dede06ae3b5590af1d4c111bc54c3f717e4b35",
-    "0x0ab87046fbb341d058f17cbc4c1133f25a20a52f",
-  ],
-  ARBITRUM: [
-    "0xf42ae1d54fd613c9bb14810b0588faaa09a426ca",
-    "0x1addd80e6039594ee970e5872d247bf0414c8903",
-    "0xd2D1162512F927a7e282Ef43a362659E4F2a728F",
-    "0xa7af63b5154eb5d6fb50a6d70d5c229e5f030ab2",
-    "0x59745774ed5eff903e615f5a2282cae03484985a",
-    "0xce3b19d820cb8b9ae370e423b0a329c4314335fe",
-    "0xb67c014fa700e69681a673876eb8bafaa36bff71",
-    "0x68f5d998f00bb2460511021741d098c05721d8ff",
-    "0xfbd849e6007f9bc3cc2d6eb159c045b8dc660268",
-    "0x7d1d610fe82482412842e8110aff1cb72fa66bc8",
-    "0xbabf696008ddade1e17d302b972376b8a7357698",
-  ],
-  POLYGON: [
-    "0x3ca3218d6c52b640b0857cc19b69aa9427bc842c",
-    "0x971039bf0a49c8d8a675f839739ee7a42511ec91",
-    "0x9d373d22fd091d7f9a6649eb067557cc12fb1a0a",
-    "0xbc4fb4ed825c65ff48163af7e59d49e32edb5269",
-    "0x8b7aa8f5cc9996216a88d900df8b8a0a3905939a",
-    "0x3ab2da31bbd886a7edf68a6b60d3cde657d3a15d",
-    "0x0cdf4195ed44fd661b4df304fb453096671b4099",
-    "0xe90056b377cbbb477e3950505ccbd8d00b9cdc75",
-    "0x5a6ae1fd70d04ba4a279fc219dfabc53825cb01d",
-    "0x11a83070d6f41ebe3764e4efed7df9b9d20a03fa",
-  ],
-  BSC: ["0xd4888870c8686c748232719051b677791dbda26d"],
-}
-
 export const FEE_COLLECTOR_CONTRACT: Partial<Record<Chain, string>> = {
   ETHEREUM: "0xe4b4c6a7c6b6396032096C12aDf46B7F14a70F4d",
   POLYGON: "0xe4b4c6a7c6b6396032096C12aDf46B7F14a70F4d",


### PR DESCRIPTION
**Changes**
- Removed the `PURCHASE_REQUIREMENT` feature flag (related backend PR: https://github.com/agoraxyz/guild-backend/pull/844)
- Removed the non-purchasable assets list which we created manually
- Created a `GET /api/nonPurchasableAssets` endpoint which retrieves the non-purchasable assets from Vercel KV
- Added the `useNonPurchasableAssets` hook, which calls this new endpoint
- Modified the `fetchPrice` endpoint so it stores non-purchasable assets in Vercel KV if we get an `INSUFFICIENT_ASSET_LIQUIDITY` error
- Refactored the `PurchaseRequirement` component and added a `DynamicPurchaseRequirement` component so I could extract the rendering logic into that one
- Added the `0x-api-key` header to the 0x API call, since it will be required from June