### PR TITLE
V2 - Paginated explorer

### DIFF
--- a/src/components/explorer/GuildCard.tsx
+++ b/src/components/explorer/GuildCard.tsx
@@ -7,7 +7,6 @@ import {
   TagLabel,
   TagLeftIcon,
   Text,
-  Tooltip,
   VStack,
   Wrap,
 } from "@chakra-ui/react"
@@ -60,13 +59,9 @@ const GuildCard = ({ guildData }: Props): JSX.Element => (
                 )}
               </TagLabel>
             </Tag>
-            <Tooltip label={guildData.roles.join(", ")}>
-              <Tag as="li">
-                <TagLabel>
-                  {pluralize(guildData.roles?.length ?? 0, "role")}
-                </TagLabel>
-              </Tag>
-            </Tooltip>
+            <Tag as="li">
+              <TagLabel>{pluralize(guildData.rolesCount ?? 0, "role")}</TagLabel>
+            </Tag>
           </Wrap>
         </VStack>
       </SimpleGrid>

--- a/src/components/explorer/YourGuilds.tsx
+++ b/src/components/explorer/YourGuilds.tsx
@@ -10,9 +10,9 @@ import GuildCardsGrid from "components/explorer/GuildCardsGrid"
 import useMemberships, {
   Memberships,
 } from "components/explorer/hooks/useMemberships"
+import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
 import { Plus, Wallet } from "phosphor-react"
 import { useEffect, useState } from "react"
-import useSWR from "swr"
 import { GuildBase } from "types"
 
 type Props = {
@@ -40,13 +40,8 @@ const YourGuilds = ({ guildsInitial }: Props) => {
   const { account } = useWeb3React()
   const { openWalletSelectorModal } = useWeb3ConnectionManager()
 
-  /**
-   * Fetching all guilds without search params to filter user's guilds out of it.
-   * `?order=members` is the default for the other filtered request too, so only one
-   * request will be sent. There'll be a separate endpoint for it in the future
-   */
-  const { data: allGuilds, isLoading: isGuildsLoading } = useSWR(
-    `/guild?order=members`,
+  const { data: allGuilds, isLoading: isGuildsLoading } = useSWRWithOptionalAuth(
+    `/guild?`, // ? is included, so the request hits v2Replacer in fetcher
     {
       fallbackData: guildsInitial,
       dedupingInterval: 60000, // one minute

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -146,7 +146,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
               <OrderSelect {...{ order, setOrder }} />
             </SimpleGrid>
 
-            {!renderedGuilds.length ? (
+            {isFilteredValidating ? null : !renderedGuilds.length ? (
               !search?.length ? (
                 <Text>
                   Can't fetch guilds from the backend right now. Check back later!

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,7 @@ type GuildBase = {
   roles: Array<string>
   platforms: Array<PlatformName>
   memberCount: number
+  rolesCount: number
 }
 
 type BrainCardData = {

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -10,6 +10,24 @@ const SIG_HEADER_NAME = "x-guild-sig"
 const PARAMS_HEADER_NAME = "x-guild-params"
 const AUTH_FLAG_HEADER_NAME = "x-guild-auth-location"
 
+const v2Replacer = (endpoint: string, options: Record<string, any>) => {
+  // if (options.method?.toLowerCase() === "post" && endpoint.includes("/v1/guild")) {
+  //   return endpoint.replace("/v1/guild", "/v2/guild/with-roles")
+  // }
+  // if (options.method?.toLowerCase() === "get" && endpoint.includes("/v1/guild/")) {
+  //   return endpoint.replace("/v1/guild/", "/v2/guild/guild-page/")
+  // }
+
+  if (
+    (options.method?.toLowerCase() ?? "get") === "get" &&
+    endpoint.startsWith(`${process.env.NEXT_PUBLIC_API}/guild?`)
+  ) {
+    return endpoint.replace("/v1/", "/v2/").replace("/guild?", "/guilds?")
+  }
+
+  return endpoint
+}
+
 const fetcher = async (
   resource: string,
   { body, validation, signedPayload, ...init }: Record<string, any> = {}
@@ -57,7 +75,11 @@ const fetcher = async (
     }
   }
 
-  return fetch(`${api}${resource}`, options).then(async (response: Response) => {
+  const endpoint = isGuildApiCall
+    ? v2Replacer(`${api}${resource}`, options)
+    : `${api}${resource}`
+
+  return fetch(endpoint, options).then(async (response: Response) => {
     const res = await response.json?.()
 
     if (!response.ok) {


### PR DESCRIPTION
# V2 - Paginated explorer

This PR aims to reimplement guilds fetching in the explorer page with the v2 paginated endpoint. User's guilds can now be obtained from this endpoint using optional authentication, so this SWR call has been modified as well
The v2 endpoint currently doesn't return roles, only rolesCounts. This is to further reduce load on the DB (we can improve on this in the future if necessary). Platforms is also not returned for the same reason