### PR TITLE
Join modal improvements for hidden requirements/rewards

### DIFF
--- a/src/components/[guild]/JoinButton.tsx
+++ b/src/components/[guild]/JoinButton.tsx
@@ -7,10 +7,15 @@ import {
 import Button from "components/common/Button"
 import { useOpenJoinModal } from "./JoinModal/JoinModalProvider"
 import useAccess from "./hooks/useAccess"
+import useGuild from "./hooks/useGuild"
+import usePlatformsToReconnect from "./hooks/usePlatformsToReconnect"
+import useUser from "./hooks/useUser"
 
 const JoinButton = (): JSX.Element => {
   const openJoinModal = useOpenJoinModal()
   const { hasAccess, isValidating } = useAccess()
+  const { requiredPlatforms } = useGuild()
+  const { platformUsers } = useUser()
 
   const buttonText = useBreakpointValue({
     base: "Join Guild",
@@ -19,7 +24,18 @@ const JoinButton = (): JSX.Element => {
 
   const bg = useColorModeValue("gray.300", "gray.800")
 
-  if (hasAccess === false || isValidating)
+  const platformsToReconnect = usePlatformsToReconnect()
+  const hasUnconnectedRequiredPlatforms = (requiredPlatforms ?? []).some(
+    (platformName) =>
+      platformUsers?.every(
+        (platformUser) => platformUser.platformName !== platformName
+      )
+  )
+
+  const shouldConnect =
+    hasUnconnectedRequiredPlatforms || platformsToReconnect?.length > 0
+
+  if (!shouldConnect && (hasAccess === false || isValidating))
     return (
       <Box bg={bg} borderRadius={"xl"}>
         <Tooltip

--- a/src/components/[guild]/JoinModal/JoinModal.tsx
+++ b/src/components/[guild]/JoinModal/JoinModal.tsx
@@ -8,13 +8,13 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { useWeb3React } from "@web3-react/core"
+import useGuild from "components/[guild]/hooks/useGuild"
 import { Error } from "components/common/Error"
 import { Modal } from "components/common/Modal"
 import ModalButton from "components/common/ModalButton"
 import DynamicDevTool from "components/create-guild/DynamicDevTool"
-import useGuild from "components/[guild]/hooks/useGuild"
 import { FormProvider, useForm } from "react-hook-form"
-import { PlatformName, PlatformType, RequirementType } from "types"
+import { PlatformName, RequirementType } from "types"
 import CompleteCaptchaJoinStep from "./components/CompleteCaptchaJoinStep"
 import ConnectPlatform from "./components/ConnectPlatform"
 import ConnectPolygonIDJoinStep from "./components/ConnectPolygonIDJoinStep"
@@ -30,13 +30,6 @@ type Props = {
 type ExtractPrefix<T> = T extends `${infer Prefix}_${string}` ? Prefix : T
 type Joinable = PlatformName | ExtractPrefix<RequirementType>
 
-const joinableRequirementPlatforms = new Set<Joinable>([
-  "TWITTER",
-  "GITHUB",
-  "CAPTCHA",
-  "POLYGON",
-])
-
 const customJoinStep: Partial<Record<Joinable, () => JSX.Element>> = {
   POLYGON: ConnectPolygonIDJoinStep,
   CAPTCHA: CompleteCaptchaJoinStep,
@@ -44,7 +37,7 @@ const customJoinStep: Partial<Record<Joinable, () => JSX.Element>> = {
 
 const JoinModal = ({ isOpen, onClose }: Props): JSX.Element => {
   const { isActive } = useWeb3React()
-  const { name, guildPlatforms, roles } = useGuild()
+  const { name, requiredPlatforms } = useGuild()
 
   const methods = useForm({
     mode: "all",
@@ -54,22 +47,7 @@ const JoinModal = ({ isOpen, onClose }: Props): JSX.Element => {
   })
   const { handleSubmit } = methods
 
-  const allJoinables = new Set<Joinable>()
-
-  guildPlatforms?.forEach((platform) =>
-    allJoinables.add(PlatformType[platform.platformId] as Joinable)
-  )
-
-  roles?.forEach((role) =>
-    role.requirements.forEach(({ type }) => {
-      const joinable = type.split("_")[0] as Joinable
-      if (joinableRequirementPlatforms.has(joinable)) {
-        allJoinables.add(joinable)
-      }
-    })
-  )
-
-  const renderedSteps = [...allJoinables].map((platform) => {
+  const renderedSteps = (requiredPlatforms ?? []).map((platform) => {
     if (platform in customJoinStep) {
       const ConnectComponent = customJoinStep[platform]
       return <ConnectComponent key={platform} />

--- a/src/components/[guild]/JoinModal/components/ConnectAccount.tsx
+++ b/src/components/[guild]/JoinModal/components/ConnectAccount.tsx
@@ -9,18 +9,30 @@ type Props = {
   colorScheme: string
   isConnected: string
   isDisabled?: string
+  isReconnect?: boolean
 } & Omit<ButtonProps, "isDisabled">
 
 const ConnectAccount = ({
   account,
   isConnected,
   children,
+  isReconnect,
   ...rest
 }: PropsWithChildren<Props>) => (
   <JoinStep
-    isDone={!!isConnected}
-    title={isConnected ? `${account} connected` : `Connect ${account}`}
-    buttonLabel={isConnected ? isConnected : "Connect"}
+    isDone={!isReconnect && !!isConnected}
+    title={
+      isConnected && !isReconnect
+        ? `${account} connected`
+        : `${isReconnect ? "Reconnect" : "Connect"} ${account}`
+    }
+    buttonLabel={
+      isConnected && !isReconnect
+        ? isConnected
+        : isReconnect
+        ? "Reconnect"
+        : "Connect"
+    }
     {...rest}
   >
     {children}

--- a/src/components/[guild]/JoinModal/components/ConnectAccount.tsx
+++ b/src/components/[guild]/JoinModal/components/ConnectAccount.tsx
@@ -22,17 +22,13 @@ const ConnectAccount = ({
   <JoinStep
     isDone={!isReconnect && !!isConnected}
     title={
-      isConnected && !isReconnect
+      isReconnect
+        ? `Reconnect ${account}`
+        : isConnected
         ? `${account} connected`
-        : `${isReconnect ? "Reconnect" : "Connect"} ${account}`
+        : `Connect ${account}`
     }
-    buttonLabel={
-      isConnected && !isReconnect
-        ? isConnected
-        : isReconnect
-        ? "Reconnect"
-        : "Connect"
-    }
+    buttonLabel={isReconnect ? "Reconnect" : isConnected || "Connect"}
     {...rest}
   >
     {children}

--- a/src/components/[guild]/JoinModal/components/ConnectPlatform.tsx
+++ b/src/components/[guild]/JoinModal/components/ConnectPlatform.tsx
@@ -20,11 +20,14 @@ const ConnectPlatform = ({ platform }: Props) => {
   const { platformUsers, isLoading: isLoadingUser } = useUser()
 
   const platformsToReconnect = usePlatformsToReconnect()
-  const { mutate: mutateAccess } = useAccess()
   const isReconnect = platformsToReconnect.includes(platform)
 
+  // we have the reconnect data from the /access endoint, so we have to mutate that on reconnect success
+  const { mutate: mutateAccess } = useAccess()
+  const onSuccess = () => isReconnect && mutateAccess()
+
   const { onConnect, isLoading, loadingText, authData, response } =
-    useConnectPlatform(platform, () => mutateAccess(), isReconnect)
+    useConnectPlatform(platform, onSuccess, isReconnect)
 
   const platformFromDb = platformUsers?.find(
     (platformAccount) => platformAccount.platformName === platform

--- a/src/components/[guild]/JoinModal/components/ConnectPlatform.tsx
+++ b/src/components/[guild]/JoinModal/components/ConnectPlatform.tsx
@@ -1,5 +1,7 @@
 import { Icon } from "@chakra-ui/react"
 import { useWeb3React } from "@web3-react/core"
+import useAccess from "components/[guild]/hooks/useAccess"
+import usePlatformsToReconnect from "components/[guild]/hooks/usePlatformsToReconnect"
 import useUser from "components/[guild]/hooks/useUser"
 import Script from "next/script"
 import platforms from "platforms/platforms"
@@ -16,8 +18,13 @@ type Props = {
 const ConnectPlatform = ({ platform }: Props) => {
   const { isActive } = useWeb3React()
   const { platformUsers, isLoading: isLoadingUser } = useUser()
+
+  const platformsToReconnect = usePlatformsToReconnect()
+  const { mutate: mutateAccess } = useAccess()
+  const isReconnect = platformsToReconnect.includes(platform)
+
   const { onConnect, isLoading, loadingText, authData, response } =
-    useConnectPlatform(platform)
+    useConnectPlatform(platform, () => mutateAccess(), isReconnect)
 
   const platformFromDb = platformUsers?.find(
     (platformAccount) => platformAccount.platformName === platform
@@ -44,6 +51,7 @@ const ConnectPlatform = ({ platform }: Props) => {
         response?.platformUserId ||
         (authData && "hidden")
       }
+      isReconnect={isReconnect}
       isLoading={isLoading || (!platformUsers && isLoadingUser)}
       onClick={onConnect}
       {...{ loadingText }}

--- a/src/components/[guild]/hooks/useAccess.ts
+++ b/src/components/[guild]/hooks/useAccess.ts
@@ -9,7 +9,7 @@ const useAccess = (roleId?: number, swrOptions?: SWRConfiguration) => {
 
   const shouldFetch = account && id && roleId !== 0
 
-  const { data, error, isValidating, mutate } = useSWRWithOptionalAuth(
+  const { data, error, isLoading, isValidating, mutate } = useSWRWithOptionalAuth(
     shouldFetch ? `/guild/access/${id}/${account}` : null,
     {
       shouldRetryOnError: false,
@@ -25,6 +25,7 @@ const useAccess = (roleId?: number, swrOptions?: SWRConfiguration) => {
     data: roleData ?? data,
     error,
     hasAccess,
+    isLoading,
     isValidating,
     mutate,
   }

--- a/src/components/[guild]/hooks/usePlatformsToReconnect.ts
+++ b/src/components/[guild]/hooks/usePlatformsToReconnect.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react"
+import { PlatformName } from "types"
+import useAccess from "./useAccess"
+
+const usePlatformsToReconnect = () => {
+  const { data: accesses } = useAccess()
+
+  const platformsToReconnect = useMemo(() => {
+    if (!accesses) {
+      return []
+    }
+
+    return [
+      ...new Set<PlatformName>(
+        (accesses ?? [])
+          ?.flatMap(({ errors }) => errors ?? [])
+          .filter(({ errorType }) => errorType === "PLATFORM_CONNECT_INVALID")
+          .map(({ subType }) => subType?.toUpperCase())
+      ),
+    ]
+  }, [accesses])
+
+  return platformsToReconnect
+}
+
+export default usePlatformsToReconnect

--- a/src/components/common/Layout/components/Account/components/AccountModal/components/SocialAccount.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/components/SocialAccount.tsx
@@ -50,7 +50,7 @@ const SocialAccount = ({ type, icon, name, colorScheme }: Props): JSX.Element =>
     accesses?.data?.some(({ errors }) =>
       errors?.some(
         ({ errorType, subType }) =>
-          errorType === "PLATFORM_CONNECT_INVALID" && subType === type
+          errorType === "PLATFORM_CONNECT_INVALID" && subType?.toUpperCase() === type
       )
     )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,7 @@ type Guild = {
   onboardingComplete: boolean
   featureFlags: FeatureFlag[]
   hiddenRoles?: boolean
+  requiredPlatforms?: PlatformName[]
 }
 type GuildFormType = Partial<
   Pick<


### PR DESCRIPTION
# Join modal improvements for hidden requirements/rewards

Backend now returns a `requiredPlatforms` field. Now we can use this in `JoinModal` to display join steps. Also adds reconnect option for these join steps, which is based on access check `errors` fields