### PR TITLE
feat: `useIsWalletConnectModalActive` hook

### DIFF
--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -32,6 +32,7 @@ import { User, WalletError } from "types"
 import { useWeb3ConnectionManager } from "../../Web3ConnectionManager"
 import ConnectorButton from "./components/ConnectorButton"
 import DelegateCashButton from "./components/DelegateCashButton"
+import useIsWalletConnectModalActive from "./hooks/useIsWalletConnectModalActive"
 import processConnectionError from "./utils/processConnectionError"
 
 type Props = {
@@ -122,6 +123,8 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
 
   const isConnected = account && isActive && ready
 
+  const isWalletConnectModalActive = useIsWalletConnectModalActive()
+
   return (
     <>
       <Modal
@@ -129,6 +132,7 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
         onClose={closeModalAndSendAction}
         closeOnOverlayClick={!isActive || !!keyPair}
         closeOnEsc={!isActive || !!keyPair}
+        trapFocus={!isWalletConnectModalActive}
       >
         <ModalOverlay />
         <ModalContent data-test="wallet-selector-modal">

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/hooks/useIsWalletConnectModalActive.ts
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/hooks/useIsWalletConnectModalActive.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react"
+
+const useIsWalletConnectModalActive = () => {
+  const [isWalletConnectModalActive, setIsWalletConnectModalActive] = useState(false)
+
+  const w3mModalRef = useRef(null)
+  useEffect(() => {
+    if (typeof window === "undefined" || w3mModalRef.current) return
+    w3mModalRef.current = document.querySelector("w3m-modal")
+  })
+
+  useEffect(() => {
+    if (!w3mModalRef.current) return
+
+    const observerTarget =
+      w3mModalRef.current.shadowRoot?.getElementById("w3m-modal")
+
+    if (!observerTarget) return
+
+    const mutationCallback: MutationCallback = (mutations, _) => {
+      const classNameChange = mutations.find(
+        (mutation) => mutation.attributeName === "class"
+      )
+      if (!classNameChange) return
+      const classNameChangeTarget = classNameChange.target as HTMLElement
+      const isW3mModalActive = classNameChangeTarget.classList.contains("w3m-active")
+
+      setIsWalletConnectModalActive(isW3mModalActive)
+    }
+
+    const observer = new MutationObserver(mutationCallback)
+
+    observer.observe(observerTarget, {
+      attributes: true,
+    })
+
+    return () => observer.disconnect()
+  }, [w3mModalRef.current])
+
+  return isWalletConnectModalActive
+}
+
+export default useIsWalletConnectModalActive


### PR DESCRIPTION
Implemented this hook, so we can check if the WalletConnect V2 modal is active, and set `trapFocus` to `false` on the `WalletSelectorModal` to make sure the users can navigate & search inside the WalletConnect modal.