### PR TITLE
address merge: remove `localStorage` usage

### DIFF
--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -45,6 +45,8 @@ const Web3Connection = createContext({
     _addressOrDomain: string,
     _platformName: PlatformName
   ) => {},
+  addressLinkParams: { userId: null as number, address: "" },
+  setAddressLinkParams: (_: { userId: number; address: string }) => {},
 })
 
 const Web3ConnectionManager = ({
@@ -79,6 +81,10 @@ const Web3ConnectionManager = ({
   const [accountMergeAddress, setAccountMergeAddress] = useState<string>("")
   const [accountMergePlatformName, setAccountMergePlatformName] =
     useState<PlatformName>()
+  const [addressLinkParams, setAddressLinkParams] = useState<{
+    userId: number
+    address: string
+  }>()
 
   const [isDelegateConnection, setIsDelegateConnection] = useState<boolean>(false)
 
@@ -147,6 +153,8 @@ const Web3ConnectionManager = ({
         isDelegateConnection,
         setIsDelegateConnection,
         isNetworkChangeInProgress,
+        addressLinkParams,
+        setAddressLinkParams,
       }}
     >
       {children}

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/hooks/useShouldLinkToUser.ts
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/hooks/useShouldLinkToUser.ts
@@ -1,0 +1,50 @@
+import { useWeb3React } from "@web3-react/core"
+import { deleteKeyPairFromIdb, getKeyPairFromIdb } from "hooks/useKeyPair"
+import useSWR, { mutate, unstable_serialize } from "swr"
+import useSWRImmutable from "swr/immutable"
+import { User } from "types"
+import { useWeb3ConnectionManager } from "../../../Web3ConnectionManager"
+
+const fetchShouldLinkToUser = async ([_, userId, connectParams]) => {
+  const { userId: userIdToConnectTo } = connectParams ?? {}
+  if (!userIdToConnectTo) return false
+
+  if (
+    typeof userId === "number" &&
+    typeof userIdToConnectTo === "number" &&
+    userIdToConnectTo !== userId
+  ) {
+    try {
+      await deleteKeyPairFromIdb(userId).then(() =>
+        mutate(unstable_serialize(["keyPair", userId]))
+      )
+    } catch {}
+  }
+
+  const keypair = await getKeyPairFromIdb(+userIdToConnectTo)
+
+  return !!keypair
+}
+
+const useShouldLinkToUser = () => {
+  const { account } = useWeb3React()
+  const { data: user } = useSWRImmutable<User>(account ? `/user/${account}` : null)
+  const { setAddressLinkParams, addressLinkParams } = useWeb3ConnectionManager()
+
+  const { data: shouldLinkToUser } = useSWR(
+    addressLinkParams?.userId
+      ? ["shouldLinkToUser", user?.id, addressLinkParams]
+      : null,
+    fetchShouldLinkToUser,
+    {
+      shouldRetryOnError: false,
+      onError: () => {
+        setAddressLinkParams({ userId: null, address: null })
+      },
+    }
+  )
+
+  return shouldLinkToUser
+}
+
+export default useShouldLinkToUser

--- a/src/components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton.tsx
@@ -12,12 +12,12 @@ import {
 } from "@chakra-ui/react"
 import { Web3Provider } from "@ethersproject/providers"
 import { useWeb3React } from "@web3-react/core"
+import LogicDivider from "components/[guild]/LogicDivider"
+import useUser from "components/[guild]/hooks/useUser"
+import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import Button from "components/common/Button"
 import useDelegateVaults from "components/common/Layout/components/Account/components/delegate/useDelegateVaults"
 import { Modal } from "components/common/Modal"
-import useUser from "components/[guild]/hooks/useUser"
-import LogicDivider from "components/[guild]/LogicDivider"
-import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import useKeyPair from "hooks/useKeyPair"
 import Image from "next/image"
 import { Plus, SignOut } from "phosphor-react"
@@ -28,7 +28,8 @@ const LinkAddressButton = ({}) => {
   const { id } = useUser()
   const { provider, connector, account } = useWeb3React<Web3Provider>()
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const { openWalletSelectorModal } = useWeb3ConnectionManager()
+  const { openWalletSelectorModal, setAddressLinkParams } =
+    useWeb3ConnectionManager()
 
   const vaults = useDelegateVaults()
   const { set } = useKeyPair()
@@ -38,7 +39,7 @@ const LinkAddressButton = ({}) => {
   const onClick = async () => {
     setIsLoading(true)
     onOpen()
-    window.localStorage.setItem("userId", JSON.stringify({ id, address: account }))
+    setAddressLinkParams({ userId: id, address: account })
 
     try {
       await provider.provider.request({


### PR DESCRIPTION
# address merge: remove `localStorage` usage

The usage of `localStorage` causes some invalid states. I think it makes sense not to use `localStorage` for this action, and instead use an SWR state, or a simple state in a context. In this PR, I've tried the latter
Seems to work fine, the problem is, that I don't remember why we implemented it with `localStorage` originally