### PR TITLE
PostHog events for measuring the time difference of OAuth code creation and join request

### DIFF
--- a/src/components/[guild]/JoinModal/hooks/useOauthPopupWindow.ts
+++ b/src/components/[guild]/JoinModal/hooks/useOauthPopupWindow.ts
@@ -1,3 +1,5 @@
+import { useWeb3React } from "@web3-react/core"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import { randomBytes } from "crypto"
 import usePopupWindow from "hooks/usePopupWindow"
 import useToast from "hooks/useToast"
@@ -29,6 +31,9 @@ const useOauthPopupWindow = <OAuthResponse = { code: string }>(
   url: string,
   oauthOptions: OAuthOptions
 ) => {
+  const { account } = useWeb3React()
+  const { captureEvent } = usePostHogContext()
+
   const toast = useToast()
 
   const redirectUri =
@@ -85,6 +90,9 @@ const useOauthPopupWindow = <OAuthResponse = { code: string }>(
             authData: null,
           })
         } else {
+          if (!account) {
+            captureEvent("OAuth without wallet connection", { platformName })
+          }
           setOauthState({
             isAuthenticating: false,
             error: null,


### PR DESCRIPTION
# PostHog events for measuring the time difference of OAuth code creation and join request

We have quite a lot of OAuth errors, that suggest that the provided authorization code is invalid or expired. Since we are supporting OAuth before wallet connection in the join modal, I'm trying to measure the largest time differences between the creation of the code, and the join request