### PR TITLE
feat(processJoinPlatformError): pretty errors

### DIFF
--- a/src/components/[guild]/JoinModal/utils/processJoinPlatformError.ts
+++ b/src/components/[guild]/JoinModal/utils/processJoinPlatformError.ts
@@ -1,6 +1,7 @@
 import { ErrorInfo } from "components/common/Error"
 import { DiscordError, WalletError } from "types"
 import processWalletError from "utils/processWalletError"
+import processConnectorError from "./processConnectorError"
 import processDiscordError from "./processDiscordError"
 
 type JoinError = WalletError | Response | Error | DiscordError | string
@@ -31,9 +32,11 @@ const processJoinPlatformError = (error: JoinError): ErrorInfo => {
     }
   }
   if (typeof error === "string") {
+    const connectorError = processConnectorError(error)
+
     return {
       title: "Error",
-      description: error,
+      description: connectorError ?? error,
     }
   }
 


### PR DESCRIPTION
I've improved the `processConnectorError` util function, so it can handle this type of connector/runner errors too:

```
\"1\" runner error in resolvePlatformUser, params: {\"code\":\"...\",\"platformName\":\"DISCORD\",\"redirect_url\":\"https://guild.xyz/oauth\",\"scope\":\"guilds identify guilds.members.read\"}, error: \"failed to resolve user\"
```