### PR TITLE
Eager connection only for last used connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "@types/node": "^18.14.2",
         "@types/react": "^18.0.26",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
+        "@web3-react/types": "^8.2.0",
         "cypress-file-upload": "^5.0.8",
         "dotenv-cli": "^7.1.0",
         "eslint": "^8.37.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@web3-react/gnosis-safe": "^8.2.1",
     "@web3-react/metamask": "^8.2.1",
     "@web3-react/walletconnect-v2": "^8.3.6",
+    "@web3-react/types": "^8.2.0",
     "chakra-react-select": "^4.5.0",
     "chakra-ui-steps": "2.1.0",
     "color": "^4.2.3",

--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -4,13 +4,13 @@ import { useWeb3React } from "@web3-react/core"
 import { WalletConnect } from "@web3-react/walletconnect-v2"
 import NetworkModal from "components/common/Layout/components/Account/components/NetworkModal/NetworkModal"
 import requestNetworkChangeHandler from "components/common/Layout/components/Account/components/NetworkModal/utils/requestNetworkChange"
-import { Chains, RPC } from "connectors"
+import { Chains, RPC, getConnectorName } from "connectors"
 import useContractWalletInfoToast from "hooks/useContractWalletInfoToast"
 import useToast from "hooks/useToast"
 import { useRouter } from "next/router"
 import {
-  createContext,
   PropsWithChildren,
+  createContext,
   useContext,
   useEffect,
   useState,
@@ -53,6 +53,12 @@ const Web3ConnectionManager = ({
 }: PropsWithChildren<any>): JSX.Element => {
   const { isActive, connector } = useWeb3React()
   const router = useRouter()
+
+  useEffect(() => {
+    if (!connector || !isActive) return
+    const connectorName = getConnectorName(connector)
+    window.localStorage.setItem("connector", connectorName)
+  }, [connector, isActive])
 
   useContractWalletInfoToast()
   useConnectFromLocalStorage()

--- a/src/components/_app/Web3ConnectionManager/hooks/useEagerConnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useEagerConnect.ts
@@ -1,5 +1,5 @@
 import { useWeb3React } from "@web3-react/core"
-import { connectors } from "connectors"
+import { connectors, connectorsByName } from "connectors"
 import { useEffect, useState } from "react"
 
 const useEagerConnect = (): boolean => {
@@ -9,25 +9,18 @@ const useEagerConnect = (): boolean => {
   const [[metaMask], , [walletConnect], [gnosisSafe]] = connectors
 
   useEffect(() => {
-    metaMask
-      .connectEagerly()
-      .catch(() => setTried(true))
-      .finally(() => setTried(true))
-  }, [metaMask])
+    if (!metaMask || !gnosisSafe || !walletConnect) {
+      return
+    }
 
-  useEffect(() => {
-    gnosisSafe
-      .connectEagerly()
-      .catch(() => setTried(true))
-      .finally(() => setTried(true))
-  }, [gnosisSafe])
+    const connector = localStorage.getItem("connector")
+    if (!connector) {
+      setTried(true)
+      return
+    }
 
-  useEffect(() => {
-    walletConnect
-      .connectEagerly()
-      .catch(() => setTried(true))
-      .finally(() => setTried(true))
-  }, [walletConnect])
+    connectorsByName[connector].connectEagerly().finally(() => setTried(true))
+  }, [metaMask, gnosisSafe, walletConnect])
 
   // if the connection worked, wait until we get confirmation of that to flip the flag
   useEffect(() => {

--- a/src/connectors/coinbaseWallet.ts
+++ b/src/connectors/coinbaseWallet.ts
@@ -2,7 +2,11 @@ import { CoinbaseWallet } from "@web3-react/coinbase-wallet"
 import { initializeConnector, Web3ReactHooks } from "@web3-react/core"
 import { RPC } from "connectors"
 
-const initializeCoinbaseWalletConnector = (): [CoinbaseWallet, Web3ReactHooks] => {
+const initializeCoinbaseWalletConnector = (): [
+  CoinbaseWallet,
+  Web3ReactHooks,
+  "coinbase"
+] => {
   /**
    * In edge runtime, the initializeConnector won't work, so as a workaround we're
    * using a try-catch here and returning an array with undefined values. This won't
@@ -21,9 +25,9 @@ const initializeCoinbaseWalletConnector = (): [CoinbaseWallet, Web3ReactHooks] =
         })
     )
 
-    return [coinbaseWallet, hooks]
+    return [coinbaseWallet, hooks, "coinbase"]
   } catch (_) {
-    return [undefined, undefined]
+    return [undefined, undefined, undefined]
   }
 }
 

--- a/src/connectors/gnosis.ts
+++ b/src/connectors/gnosis.ts
@@ -1,7 +1,7 @@
 import { initializeConnector, Web3ReactHooks } from "@web3-react/core"
 import { GnosisSafe } from "@web3-react/gnosis-safe"
 
-const initializeGnosisConnector = (): [GnosisSafe, Web3ReactHooks] => {
+const initializeGnosisConnector = (): [GnosisSafe, Web3ReactHooks, "gnosis"] => {
   /**
    * In edge runtime, the initializeConnector won't work, so as a workaround we're
    * using a try-catch here and returning an array with undefined values. This won't
@@ -16,9 +16,9 @@ const initializeGnosisConnector = (): [GnosisSafe, Web3ReactHooks] => {
         })
     )
 
-    return [gnosis, hooks]
+    return [gnosis, hooks, "gnosis"]
   } catch (_) {
-    return [undefined, undefined]
+    return [undefined, undefined, undefined]
   }
 }
 

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -2,6 +2,7 @@ import { CoinbaseWallet } from "@web3-react/coinbase-wallet"
 import { Web3ReactHooks } from "@web3-react/core"
 import { GnosisSafe } from "@web3-react/gnosis-safe"
 import { MetaMask } from "@web3-react/metamask"
+import { Connector } from "@web3-react/types"
 import { WalletConnect } from "@web3-react/walletconnect-v2"
 import initializeCoinbaseWalletConnector from "./coinbaseWallet"
 import initializeGnosisConnector from "./gnosis"
@@ -648,10 +649,12 @@ supportedChains.forEach(
   (chain) => (RPC_URLS[RPC[chain].chainId] = RPC[chain].rpcUrls)
 )
 
-const [metaMask, metaMaskHooks] = initializeMetaMaskConnector()
-const [walletConnect, walletConnectHooks] = initializeWalletConnectConnector()
-const [coinbaseWallet, coinbaseWalletHooks] = initializeCoinbaseWalletConnector()
-const [gnosisWallet, gnosisWalletHooks] = initializeGnosisConnector()
+const [metaMask, metaMaskHooks, metaMaskName] = initializeMetaMaskConnector()
+const [walletConnect, walletConnectHooks, walletConnectName] =
+  initializeWalletConnectConnector()
+const [coinbaseWallet, coinbaseWalletHooks, coinbaseName] =
+  initializeCoinbaseWalletConnector()
+const [gnosisWallet, gnosisWalletHooks, gnosisName] = initializeGnosisConnector()
 
 const connectors: [
   MetaMask | WalletConnect | CoinbaseWallet | GnosisSafe,
@@ -663,4 +666,26 @@ const connectors: [
   [gnosisWallet, gnosisWalletHooks],
 ]
 
-export { Chains, RPC, RPC_URLS, connectors, supportedChains }
+const connectorsByName = {
+  [metaMaskName]: metaMask,
+  [walletConnectName]: walletConnect,
+  [coinbaseName]: coinbaseWallet,
+  [gnosisName]: gnosisWallet,
+}
+
+type ConnectorName = keyof typeof connectorsByName
+
+const getConnectorName = (connector: Connector): ConnectorName =>
+  (Object.entries(connectorsByName) as [ConnectorName, Connector][]).find(
+    ([, conn]) => conn === connector
+  )[0]
+
+export {
+  Chains,
+  RPC,
+  RPC_URLS,
+  connectors,
+  connectorsByName,
+  getConnectorName,
+  supportedChains,
+}

--- a/src/connectors/metaMask.ts
+++ b/src/connectors/metaMask.ts
@@ -1,7 +1,7 @@
 import { initializeConnector, Web3ReactHooks } from "@web3-react/core"
 import { MetaMask } from "@web3-react/metamask"
 
-const initializeMetaMaskConnector = (): [MetaMask, Web3ReactHooks] => {
+const initializeMetaMaskConnector = (): [MetaMask, Web3ReactHooks, "metamask"] => {
   /**
    * In edge runtime, the initializeConnector won't work, so as a workaround we're
    * using a try-catch here and returning an array with undefined values. This won't
@@ -19,9 +19,9 @@ const initializeMetaMaskConnector = (): [MetaMask, Web3ReactHooks] => {
         })
     )
 
-    return [metaMask, hooks]
+    return [metaMask, hooks, "metamask"]
   } catch (_) {
-    return [undefined, undefined]
+    return [undefined, undefined, undefined]
   }
 }
 

--- a/src/connectors/walletConnect.ts
+++ b/src/connectors/walletConnect.ts
@@ -2,7 +2,11 @@ import { initializeConnector, Web3ReactHooks } from "@web3-react/core"
 import { WalletConnect } from "@web3-react/walletconnect-v2"
 import { RPC } from "connectors"
 
-const initializeWalletConnectConnector = (): [WalletConnect, Web3ReactHooks] => {
+const initializeWalletConnectConnector = (): [
+  WalletConnect,
+  Web3ReactHooks,
+  "walletconnect"
+] => {
   /**
    * In edge runtime, the initializeConnector won't work, so as a workaround we're
    * using a try-catch here and returning an array with undefined values. This won't
@@ -32,9 +36,9 @@ const initializeWalletConnectConnector = (): [WalletConnect, Web3ReactHooks] => 
       })
     })
 
-    return [walletConnect, hooks]
+    return [walletConnect, hooks, "walletconnect"]
   } catch (_) {
-    return [undefined, undefined]
+    return [undefined, undefined, undefined]
   }
 }
 


### PR DESCRIPTION
# Eager connection only for last used connector

This PR aims to make WalletConnect connections persistent by only connecting eagerly to the last used connector