### PR TITLE
Fix non-discord templated guild creation

### DIFF
--- a/src/components/create-guild/CreateGuildContext.tsx
+++ b/src/components/create-guild/CreateGuildContext.tsx
@@ -172,7 +172,7 @@ const CreateGuildProvider = ({
               },
             },
           ],
-          rolePlatforms: platform === "TELEGRAM" ? undefined : rolePlatforms,
+          rolePlatforms: platform === "DISCORD" ? rolePlatforms : undefined,
         },
       ] as any[],
     },

--- a/src/components/create-guild/CreateGuildContext.tsx
+++ b/src/components/create-guild/CreateGuildContext.tsx
@@ -172,7 +172,7 @@ const CreateGuildProvider = ({
               },
             },
           ],
-          rolePlatforms,
+          rolePlatforms: platform === "TELEGRAM" ? undefined : rolePlatforms,
         },
       ] as any[],
     },


### PR DESCRIPTION
# Fix non-discord templated guild creation

~~Telegram guild creation currently fails when using the growth template, because it adds the Telegram reward to both roles by default. This PR aims to fix this issue by only adding the Telegram reward to one of the roles~~

I realized this is a problem with GitHub and Google as well, not just Telegram, so I've changed it to only include the second reward if the platform is Discord

