### PR TITLE
ERC-1155 UI changes

### DIFF
--- a/src/components/[guild]/Requirements/components/BlockExplorerUrl.tsx
+++ b/src/components/[guild]/Requirements/components/BlockExplorerUrl.tsx
@@ -14,7 +14,7 @@ const BlockExplorerUrl = ({
   address: addressProp,
 }: Props): JSX.Element => {
   const { colorMode } = useColorMode()
-  const { chain, type, address } = useRequirementContext()
+  const { chain, type, address, data } = useRequirementContext()
 
   const blockExplorer = RPC[chainProp ?? chain]?.blockExplorerUrls?.[0]
 
@@ -23,9 +23,13 @@ const BlockExplorerUrl = ({
   // explorer.zksync.io doesn't support the /token path
   const path = (chainProp ?? chain) === "ZKSYNC_ERA" ? "address" : "token"
 
+  const url = data?.id
+    ? `${blockExplorer}/nft/${addressProp ?? address}/${data?.id}`
+    : `${blockExplorer}/${path}/${addressProp ?? address}`
+
   return (
     <RequirementLinkButton
-      href={`${blockExplorer}/${path}/${addressProp ?? address}`}
+      href={url}
       imageUrl={RPC[chainProp ?? chain]?.blockExplorerIcons[colorMode]}
     >
       View on explorer

--- a/src/components/[guild]/Requirements/components/BlockExplorerUrl.tsx
+++ b/src/components/[guild]/Requirements/components/BlockExplorerUrl.tsx
@@ -23,9 +23,10 @@ const BlockExplorerUrl = ({
   // explorer.zksync.io doesn't support the /token path
   const path = (chainProp ?? chain) === "ZKSYNC_ERA" ? "address" : "token"
 
-  const url = data?.id
-    ? `${blockExplorer}/nft/${addressProp ?? address}/${data?.id}`
-    : `${blockExplorer}/${path}/${addressProp ?? address}`
+  const url =
+    (type === "ERC1155" || type === "ERC721") && data?.id
+      ? `${blockExplorer}/nft/${addressProp ?? address}/${data?.id}`
+      : `${blockExplorer}/${path}/${addressProp ?? address}`
 
   return (
     <RequirementLinkButton

--- a/src/requirements/Nft/NftRequirement.tsx
+++ b/src/requirements/Nft/NftRequirement.tsx
@@ -108,7 +108,9 @@ const NftRequirement = (props: RequirementProps) => {
     >
       {"Own "}
       {requirement.data?.id
-        ? "the "
+        ? requirement.type === "ERC1155"
+          ? "a(n) "
+          : "the "
         : requirement.data?.maxAmount > 0
         ? `${requirement.data?.minAmount}-${requirement.data?.maxAmount} `
         : requirement.data?.minAmount > 1
@@ -163,6 +165,12 @@ const NftRequirement = (props: RequirementProps) => {
             : ""
         }`
       )}
+      {requirement.data?.id ? (
+        <>
+          {" "}
+          with id <DataBlock>{requirement.data?.id}</DataBlock>
+        </>
+      ) : null}
     </Requirement>
   )
 }


### PR DESCRIPTION
# ERC-1155 UI changes

This PR includes some small UI changes according to feedback here: https://discord.com/channels/697041998728659035/1143520047344652339/1144229221737189496

- `NftRequirement`: display the id, which the requirement is checking for, and use "a(n)" instead of "the" for `ERC1155`
- `BlockExplorerUrl`: Checks if the current requirement is either `ERC721` or `ERC1155`, and has a `data.id` field and if it does, use a link directly to that id