### PR TITLE
POAP hotfixes

### DIFF
--- a/src/components/[guild]/AddRewardButton/AddRewardButton.tsx
+++ b/src/components/[guild]/AddRewardButton/AddRewardButton.tsx
@@ -26,6 +26,7 @@ import {
   RoleTypeToAddTo,
   useAddRewardContext,
 } from "../AddRewardContext"
+import { CreatePoapProvider } from "../CreatePoap/components/CreatePoapContext"
 import { useIsTabsStuck } from "../Tabs/Tabs"
 import { useThemeContext } from "../ThemeContext"
 import useAddReward from "./hooks/useAddReward"
@@ -121,70 +122,73 @@ const AddRewardButton = (): JSX.Element => {
           colorScheme="dark"
         >
           <ModalOverlay />
-          <ModalContent minH="550px">
-            <ModalCloseButton />
-            <ModalHeader
-              {...(step === "SELECT_ROLE"
-                ? {
-                    bgColor: lightModalBgColor,
-                    boxShadow: "sm",
-                    zIndex: 1,
-                  }
-                : {})}
-            >
-              <Stack spacing={8}>
-                <HStack>
-                  {selection && (
-                    <IconButton
-                      isDisabled={isBackButtonDisabled}
-                      rounded="full"
-                      aria-label="Back"
-                      size="sm"
-                      mb="-3px"
-                      icon={<ArrowLeft size={20} />}
-                      variant="ghost"
-                      onClick={goBack}
-                    />
-                  )}
-                  <Text>
-                    {selection
-                      ? `Add ${platforms[selection].name} reward`
-                      : "Add reward"}
-                  </Text>
-                </HStack>
+          {/* TODO: this is a temporary solution, we should remove this from here when POAPs become real rewards */}
+          <CreatePoapProvider>
+            <ModalContent minH="550px">
+              <ModalCloseButton />
+              <ModalHeader
+                {...(step === "SELECT_ROLE"
+                  ? {
+                      bgColor: lightModalBgColor,
+                      boxShadow: "sm",
+                      zIndex: 1,
+                    }
+                  : {})}
+              >
+                <Stack spacing={8}>
+                  <HStack>
+                    {selection && (
+                      <IconButton
+                        isDisabled={isBackButtonDisabled}
+                        rounded="full"
+                        aria-label="Back"
+                        size="sm"
+                        mb="-3px"
+                        icon={<ArrowLeft size={20} />}
+                        variant="ghost"
+                        onClick={goBack}
+                      />
+                    )}
+                    <Text>
+                      {selection
+                        ? `Add ${platforms[selection].name} reward`
+                        : "Add reward"}
+                    </Text>
+                  </HStack>
 
-                {step === "SELECT_ROLE" && <PlatformPreview />}
-              </Stack>
-            </ModalHeader>
+                  {step === "SELECT_ROLE" && <PlatformPreview />}
+                </Stack>
+              </ModalHeader>
 
-            <ModalBody ref={modalRef} className="custom-scrollbar">
-              {selection === "POAP" ? (
-                <DynamicAddPoapPanel />
-              ) : selection && step === "SELECT_ROLE" ? (
-                <SelectRoleOrSetRequirements selectedPlatform={selection} />
-              ) : AddPlatformPanel ? (
-                <AddPlatformPanel
-                  onSuccess={() => setStep("SELECT_ROLE")}
-                  skipSettings
-                />
-              ) : (
-                <PlatformsGrid onSelection={setSelection} showPoap />
+              <ModalBody ref={modalRef} className="custom-scrollbar">
+                {selection === "POAP" ? (
+                  <DynamicAddPoapPanel />
+                ) : selection && step === "SELECT_ROLE" ? (
+                  <SelectRoleOrSetRequirements selectedPlatform={selection} />
+                ) : AddPlatformPanel ? (
+                  <AddPlatformPanel
+                    onSuccess={() => setStep("SELECT_ROLE")}
+                    skipSettings
+                  />
+                ) : (
+                  <PlatformsGrid onSelection={setSelection} showPoap />
+                )}
+              </ModalBody>
+
+              {selection !== "POAP" && step === "SELECT_ROLE" && (
+                <ModalFooter pt="6" pb="8">
+                  <Button
+                    isDisabled={isAddRewardButtonDisabled}
+                    colorScheme="green"
+                    onClick={methods.handleSubmit(onSubmit)}
+                    isLoading={isLoading}
+                  >
+                    Done
+                  </Button>
+                </ModalFooter>
               )}
-            </ModalBody>
-
-            {selection !== "POAP" && step === "SELECT_ROLE" && (
-              <ModalFooter pt="6" pb="8">
-                <Button
-                  isDisabled={isAddRewardButtonDisabled}
-                  colorScheme="green"
-                  onClick={methods.handleSubmit(onSubmit)}
-                  isLoading={isLoading}
-                >
-                  Done
-                </Button>
-              </ModalFooter>
-            )}
-          </ModalContent>
+            </ModalContent>
+          </CreatePoapProvider>
         </Modal>
       </FormProvider>
     </>

--- a/src/components/[guild]/CreatePoap/AddPoapPanel.tsx
+++ b/src/components/[guild]/CreatePoap/AddPoapPanel.tsx
@@ -1,7 +1,6 @@
 import { Box, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react"
 import { useFormContext } from "react-hook-form"
 import { useAddRewardContext } from "../AddRewardContext"
-import { CreatePoapProvider } from "./components/CreatePoapContext"
 import ImportPoap from "./components/ImportPoap"
 import CreatePoapForm from "./components/PoapDataForm/CreatePoapForm"
 import { SetupPoapRequirements } from "./components/PoapRequirements/PoapRequirements"
@@ -41,10 +40,4 @@ const AddPoapPanel = (): JSX.Element => {
   )
 }
 
-const AddPoapPanelWrapper = (): JSX.Element => (
-  <CreatePoapProvider>
-    <AddPoapPanel />
-  </CreatePoapProvider>
-)
-
-export default AddPoapPanelWrapper
+export default AddPoapPanel

--- a/src/components/[guild]/CreatePoap/components/EditPoapRole/EditPoapRole.tsx
+++ b/src/components/[guild]/CreatePoap/components/EditPoapRole/EditPoapRole.tsx
@@ -53,7 +53,8 @@ const EditPoapRole = ({ poap, guildPoap }: Props): JSX.Element => {
     description: poap.description,
     imageUrl: poap.image_url,
     requirements: mapRequirements(guildPoap.poapRequirements),
-    logic: "OR",
+    // Pretty messy, but will be removed once POAP becames a real reward
+    logic: (guildPoap.poapRequirements?.[0] as any)?.logic ?? "OR",
   }
   const methods = useForm({
     mode: "all",

--- a/src/platforms/Poap/DeactivatePoapMenuItem.tsx
+++ b/src/platforms/Poap/DeactivatePoapMenuItem.tsx
@@ -20,7 +20,7 @@ const DeactivatePoapMenuItem = ({ guildPoap }: Props): JSX.Element => {
     <MenuItem
       isDisabled={isLoading}
       icon={isLoading ? <Spinner size="xs" /> : <LockSimple />}
-      onClick={() => onSubmit({ id: guildPoap.id, activate: false })}
+      onClick={() => onSubmit({ id: guildPoap.id, activated: false })}
     >
       Deactivate POAP
     </MenuItem>


### PR DESCRIPTION
- Moved `CreatePoapContext` to a higher level, so we can properly display POAP data inside the `PoapPreview` components
- Fixed the default value for the `logic` field inside `EditPoapDrawer`
- Fixed `DeactivatePoapMenuItem` - we've sent an invalid parameter so users couldn't deactivate POAPs