### PR TITLE
Fix invalid form default values

### DIFF
--- a/src/components/[guild]/CreatePoap/components/PoapRoleCard/PoapRoleCard.tsx
+++ b/src/components/[guild]/CreatePoap/components/PoapRoleCard/PoapRoleCard.tsx
@@ -18,13 +18,13 @@ import {
   Wrap,
   WrapItem,
 } from "@chakra-ui/react"
+import Card from "components/common/Card"
+import Link from "components/common/Link"
 import useUserPoapEligibility from "components/[guild]/claim-poap/hooks/useUserPoapEligibility"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useGuildPermission from "components/[guild]/hooks/useGuildPermission"
 import LogicDivider from "components/[guild]/LogicDivider"
 import RequirementDisplayComponent from "components/[guild]/Requirements/components/RequirementDisplayComponent"
-import Card from "components/common/Card"
-import Link from "components/common/Link"
 import { ArrowSquareOut, Clock } from "phosphor-react"
 import React, { useMemo } from "react"
 import FreeRequirement from "requirements/Free/FreeRequirement"
@@ -47,7 +47,7 @@ type Props = {
 
 const PoapRoleCard = ({ guildPoap }: Props): JSX.Element => {
   const { colorMode } = useColorMode()
-  const { urlName } = useGuild()
+  const { urlName, isDetailed } = useGuild()
   const { isAdmin } = useGuildPermission()
   const { poap, isLoading } = usePoap(guildPoap.fancyId)
   const { poapEventDetails } = usePoapEventDetails(poap?.id)
@@ -207,7 +207,7 @@ const PoapRoleCard = ({ guildPoap }: Props): JSX.Element => {
                 </Wrap>
               </Stack>
             </HStack>
-            {isAdmin && (
+            {isAdmin && isDetailed && (
               <>
                 <Spacer m="0 !important" />
                 {poap && guildPoap ? (

--- a/src/components/[guild]/RoleCard/RoleCard.tsx
+++ b/src/components/[guild]/RoleCard/RoleCard.tsx
@@ -38,7 +38,7 @@ type Props = {
 const DynamicEditRole = dynamic(() => import("./components/EditRole"))
 
 const RoleCard = memo(({ role }: Props) => {
-  const { guildPlatforms } = useGuild()
+  const { guildPlatforms, isDetailed } = useGuild()
   const { isAdmin } = useGuildPermission()
   const isMember = useIsMember()
   const { hasAccess } = useAccess(role.id)
@@ -160,7 +160,7 @@ const RoleCard = memo(({ role }: Props) => {
               >
                 <MemberCount memberCount={role.memberCount} roleId={role.id} />
 
-                {isAdmin && (
+                {isAdmin && isDetailed && (
                   <>
                     <Spacer m="0 !important" />
                     <DynamicEditRole roleId={role.id} />

--- a/src/components/[guild]/hooks/useGuild.ts
+++ b/src/components/[guild]/hooks/useGuild.ts
@@ -1,5 +1,3 @@
-import { useWeb3React } from "@web3-react/core"
-import useKeyPair from "hooks/useKeyPair"
 import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
 import { useRouter } from "next/router"
 import { Guild } from "types"
@@ -9,10 +7,7 @@ const useGuild = (guildId?: string | number) => {
 
   const id = guildId ?? router.query.guild
 
-  const { keyPair } = useKeyPair()
-  const { account } = useWeb3React()
-
-  const { data, mutate, isLoading } = useSWRWithOptionalAuth<Guild>(
+  const { data, mutate, isLoading, isSigned } = useSWRWithOptionalAuth<Guild>(
     id ? `/v2/guilds/guild-page/${id}` : null,
     undefined,
     undefined,
@@ -21,7 +16,7 @@ const useGuild = (guildId?: string | number) => {
 
   return {
     ...data,
-    isDetailed: !!keyPair && !!account && !!data,
+    isDetailed: isSigned,
     isLoading,
     mutateGuild: mutate,
   }

--- a/src/hooks/useSWRWithOptionalAuth.ts
+++ b/src/hooks/useSWRWithOptionalAuth.ts
@@ -11,7 +11,7 @@ const useSWRWithOptionalAuth = <Data = any, Error = any>(
   options: SWRSettings = {},
   isMutable = false,
   onlyAuthRequest = true
-): SWRResponse<Data, Error> => {
+): SWRResponse<Data, Error> & { isSigned: boolean } => {
   const useSWRHook = isMutable ? useSWR : useSWRImmutable
 
   const { account } = useWeb3React()
@@ -37,6 +37,7 @@ const useSWRWithOptionalAuth = <Data = any, Error = any>(
     isValidating: authenticatedResponse.isValidating ?? publicResponse.isValidating,
     mutate: authenticatedResponse.mutate ?? publicResponse.mutate,
     error: authenticatedResponse.error ?? publicResponse.error,
+    isSigned: !!authenticatedResponse.data,
   }
 }
 

--- a/src/pages/[guild]/index.tsx
+++ b/src/pages/[guild]/index.tsx
@@ -47,7 +47,7 @@ import Head from "next/head"
 import ErrorPage from "pages/_error"
 import { Info, Users } from "phosphor-react"
 import React, { useMemo, useRef, useState } from "react"
-import { SWRConfig, unstable_serialize } from "swr"
+import { SWRConfig } from "swr"
 import { Guild, PlatformType, SocialLinkKey, Visibility } from "types"
 import fetcher from "utils/fetcher"
 import parseDescription from "utils/parseDescription"
@@ -90,6 +90,7 @@ const GuildPage = (): JSX.Element => {
     poaps,
     guildPlatforms,
     tags,
+    isDetailed,
   } = useGuild()
   useAutoStatusUpdate()
 
@@ -226,7 +227,7 @@ const GuildPage = (): JSX.Element => {
         imageUrl={imageUrl}
         background={localThemeColor}
         backgroundImage={localBackgroundImage}
-        action={isAdmin && <DynamicEditGuildButton />}
+        action={isAdmin && isDetailed && <DynamicEditGuildButton />}
         backButton={{ href: "/explorer", text: "Go back to explorer" }}
         titlePostfix={
           tags?.includes("VERIFIED") && (
@@ -439,12 +440,7 @@ const getStaticProps: GetStaticProps = async ({ params }) => {
     props: {
       fallback: {
         [`/guild/${params.guild?.toString()}`]: filteredData,
-        [unstable_serialize([
-          `/guild/${params.guild?.toString()}`,
-          { method: "GET", body: {} },
-        ])]: filteredData,
         [endpoint]: filteredData,
-        [unstable_serialize([endpoint, { method: "GET", body: {} }])]: filteredData,
       },
     },
     revalidate: 300,


### PR DESCRIPTION
## Bugfix

### Describe the bug

In some cases, we have invalid data as the guild edit form's `defaultValues`. This happens when the drawer mounts before the guild data is fetched. In this case, the statically generated guild data is used, which can contain invalid data

### Steps to reproduce

This bug can't be consistently reproduced, but performing the following actions, and then refreshing the site until invalid data appears in the drawer can produce the bug

1. Open a guild in which you are admin
2. Add a new admin to the guild
3. Start refreshing the site until invalid data appears in the drawer

### How this PR solves the issue

- `useSWRWithOptionalAuth` now returns an `isSigned` parameter that tells if the returned data came from a signed request's response
- Removes the statically generated data from signed data's fallback in the guild page's `getStaticProps`. This means that we don't have any data in the signed version in SWR until an actually signed request is sent and a response is received. This makes the new `isSigned` param correct
- The bug should be fixed by having the mount of the drawer bound to `isSigned`