### PR TITLE
hotfix: optional auth SWR error

### DIFF
--- a/src/hooks/useSWRWithOptionalAuth.ts
+++ b/src/hooks/useSWRWithOptionalAuth.ts
@@ -19,15 +19,15 @@ const useSWRWithOptionalAuth = <Data = any, Error = any>(
 
   const shouldSendAuth = !!keyPair && ready && isValid && !!account
 
-  const publicResponse = useSWRImmutable<Data, Error, any>(
-    url && !onlyAuthRequest && !shouldSendAuth ? url : null,
-    options as any
-  )
-
   const fetcherWithSign = useFetcherWithSign()
   const authenticatedResponse = useSWRHook<Data, Error, any>(
     url && shouldSendAuth ? [url, { method: "GET", body: {} }] : null,
     fetcherWithSign,
+    options as any
+  )
+
+  const publicResponse = useSWRImmutable<Data, Error, any>(
+    url && !onlyAuthRequest && !authenticatedResponse.data ? url : null,
     options as any
   )
 


### PR DESCRIPTION
# hotfix: optional auth SWR error

Due to https://github.com/agoraxyz/guild.xyz/commit/add059fe49efd926f106ed099a090abffb5b99bb, guild data was `undefined` for the duration of the authenticated request. This PR fixes this by binding the unauthenticated request's `shouldFetch` to `authenticatedResponse.data`, so it only stops fetching once we have authenticated data