### PR TITLE
feat: TransactionStatusContext

### DIFF
--- a/src/components/[guild]/Requirements/components/GuildCheckout/BuyPass.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/BuyPass.tsx
@@ -14,35 +14,36 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { useWeb3React } from "@web3-react/core"
-import PoapReward from "components/[guild]/CreatePoap/components/PoapReward"
-import Reward from "components/[guild]/RoleCard/components/Reward"
-import useAccess from "components/[guild]/hooks/useAccess"
-import useGuild from "components/[guild]/hooks/useGuild"
-import { usePostHogContext } from "components/_app/PostHogProvider"
 import Button from "components/common/Button"
 import { Modal } from "components/common/Modal"
+import PoapReward from "components/[guild]/CreatePoap/components/PoapReward"
+import useAccess from "components/[guild]/hooks/useAccess"
+import useGuild from "components/[guild]/hooks/useGuild"
+import Reward from "components/[guild]/RoleCard/components/Reward"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import { Chains } from "connectors"
 import { Coin } from "phosphor-react"
 import { useEffect } from "react"
 import { usePoap } from "requirements/Poap/hooks/usePoaps"
 import { paymentSupportedChains } from "utils/guildCheckout/constants"
+import { useRequirementContext } from "../RequirementContext"
 import AlphaTag from "./components/AlphaTag"
+import BuyAllowanceButton from "./components/buttons/BuyAllowanceButton"
+import BuyButton from "./components/buttons/BuyButton"
+import SwitchNetworkButton from "./components/buttons/SwitchNetworkButton"
 import BuyTotal from "./components/BuyTotal"
 import { useGuildCheckoutContext } from "./components/GuildCheckoutContex"
 import NoReward from "./components/NoReward"
 import PaymentFeeCurrency from "./components/PaymentFeeCurrency"
 import PaymentMethodButtons from "./components/PaymentMethodButtons"
 import TOSCheckbox from "./components/TOSCheckbox"
-import BuyAllowanceButton from "./components/buttons/BuyAllowanceButton"
-import BuyButton from "./components/buttons/BuyButton"
-import SwitchNetworkButton from "./components/buttons/SwitchNetworkButton"
 
 const BuyPass = () => {
   const { captureEvent } = usePostHogContext()
 
   const { account, chainId } = useWeb3React()
-  const { requirement, isOpen, onOpen, onClose, setAgreeWithTOS } =
-    useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { isOpen, onOpen, onClose, setAgreeWithTOS } = useGuildCheckoutContext()
   const { urlName, name, roles, poaps } = useGuild()
   const role = roles?.find((r) => r.id === requirement?.roleId)
 

--- a/src/components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement.tsx
@@ -6,6 +6,7 @@ import {
   PURCHASABLE_REQUIREMENT_TYPES,
   purchaseSupportedChains,
 } from "utils/guildCheckout/constants"
+import { useRequirementContext } from "../RequirementContext"
 import { useGuildCheckoutContext } from "./components/GuildCheckoutContex"
 import { useTransactionStatusContext } from "./components/TransactionStatusContext"
 
@@ -19,7 +20,8 @@ const DynamicallyLoadedPurchaseRequirement = dynamic(
 const DynamicPurchaseRequirement = () => {
   const { data } = useNonPurchasableAssets()
 
-  const { requirement, isOpen } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { isOpen } = useGuildCheckoutContext()
   const { isTxModalOpen } = useTransactionStatusContext()
 
   const { data: accessData, isValidating: isAccessValidating } = useAccess(

--- a/src/components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/DynamicPurchaseRequirement.tsx
@@ -7,6 +7,7 @@ import {
   purchaseSupportedChains,
 } from "utils/guildCheckout/constants"
 import { useGuildCheckoutContext } from "./components/GuildCheckoutContex"
+import { useTransactionStatusContext } from "./components/TransactionStatusContext"
 
 const DynamicallyLoadedPurchaseRequirement = dynamic(
   () => import("./PurchaseRequirement"),
@@ -18,7 +19,8 @@ const DynamicallyLoadedPurchaseRequirement = dynamic(
 const DynamicPurchaseRequirement = () => {
   const { data } = useNonPurchasableAssets()
 
-  const { requirement, isOpen, isInfoModalOpen } = useGuildCheckoutContext()
+  const { requirement, isOpen } = useGuildCheckoutContext()
+  const { isTxModalOpen } = useTransactionStatusContext()
 
   const { data: accessData, isValidating: isAccessValidating } = useAccess(
     requirement?.roleId
@@ -29,7 +31,7 @@ const DynamicPurchaseRequirement = () => {
 
   const shouldNotRenderComponent =
     !isOpen &&
-    !isInfoModalOpen &&
+    !isTxModalOpen &&
     ((!accessData && isAccessValidating) ||
       satisfiesRequirement ||
       !PURCHASABLE_REQUIREMENT_TYPES.includes(requirement.type) ||

--- a/src/components/[guild]/Requirements/components/GuildCheckout/PurchaseRequirement.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/PurchaseRequirement.tsx
@@ -19,6 +19,7 @@ import { usePostHogContext } from "components/_app/PostHogProvider"
 import { Chains, RPC } from "connectors"
 import { ShoppingCartSimple } from "phosphor-react"
 import BlockExplorerUrl from "../BlockExplorerUrl"
+import { useRequirementContext } from "../RequirementContext"
 import AlphaTag from "./components/AlphaTag"
 import ConnectWalletButton from "./components/buttons/ConnectWalletButton"
 import PurchaseAllowanceButton from "./components/buttons/PurchaseAllowanceButton"
@@ -37,7 +38,10 @@ const PurchaseRequirement = (): JSX.Element => {
   const { captureEvent } = usePostHogContext()
 
   const { account, chainId } = useWeb3React()
-  const { requirement, isOpen, onOpen, onClose } = useGuildCheckoutContext()
+
+  const requirement = useRequirementContext()
+  const { isOpen, onOpen, onClose } = useGuildCheckoutContext()
+
   const { urlName, name } = useGuild()
 
   const {

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/BuyTotal.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/BuyTotal.tsx
@@ -3,13 +3,16 @@ import { formatUnits } from "@ethersproject/units"
 import { RPC } from "connectors"
 import useTokenData from "hooks/useTokenData"
 import useVault from "requirements/Payment/hooks/useVault"
+import { useRequirementContext } from "../../RequirementContext"
 import usePayFee from "../hooks/usePayFee"
 import FeesTable from "./FeesTable"
 import { useGuildCheckoutContext } from "./GuildCheckoutContex"
 import PriceFallback from "./PriceFallback"
 
 const BuyTotal = (): JSX.Element => {
-  const { requirement, pickedCurrency } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency } = useGuildCheckoutContext()
+
   const {
     data: { token, fee },
     isValidating,

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex.tsx
@@ -1,7 +1,4 @@
 import { useDisclosure } from "@chakra-ui/react"
-import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
-import useAccess from "components/[guild]/hooks/useAccess"
-import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
 import {
   createContext,
   Dispatch,
@@ -44,24 +41,15 @@ const GuildCheckoutProvider = ({
   const [pickedCurrency, setPickedCurrency] = useState<string>()
   const [agreeWithTOS, setAgreeWithTOS] = useState(false)
 
-  const triggerConfetti = useJsConfetti()
-
   useEffect(() => {
     if (!txHash || !isOpen || isTxModalOpen) return
     onClose()
     onTxModalOpen()
   }, [txHash])
 
-  useEffect(() => {
-    if (!txSuccess) return
-    triggerConfetti()
-    mutateAccess()
-  }, [txSuccess])
-
   return (
     <GuildCheckoutContext.Provider
       value={{
-        requirement,
         isOpen,
         onOpen,
         onClose,

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex.tsx
@@ -12,25 +12,20 @@ import {
   useState,
 } from "react"
 import { Requirement } from "types"
+import {
+  TransactionStatusProvider,
+  useTransactionStatusContext,
+} from "./TransactionStatusContext"
 
 export type GuildCheckoutContextType = {
   requirement: Requirement
   isOpen: boolean
   onOpen: () => void
   onClose: () => void
-  isInfoModalOpen: boolean
-  onInfoModalOpen: () => void
-  onInfoModalClose: () => void
   pickedCurrency: string
   setPickedCurrency: Dispatch<SetStateAction<string>>
   agreeWithTOS: boolean
   setAgreeWithTOS: Dispatch<SetStateAction<boolean>>
-  txHash: string
-  setTxHash: Dispatch<SetStateAction<string>>
-  txSuccess: boolean
-  setTxSuccess: Dispatch<SetStateAction<boolean>>
-  txError: boolean
-  setTxError: Dispatch<SetStateAction<boolean>>
 }
 
 const GuildCheckoutContext = createContext<GuildCheckoutContextType>(undefined)
@@ -41,25 +36,20 @@ const GuildCheckoutProvider = ({
   const requirement = useRequirementContext()
   const { mutate: mutateAccess } = useAccess(requirement?.roleId)
 
+  const { isTxModalOpen, onTxModalOpen, txHash, txSuccess } =
+    useTransactionStatusContext()
+
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const {
-    isOpen: isInfoModalOpen,
-    onOpen: onInfoModalOpen,
-    onClose: onInfoModalClose,
-  } = useDisclosure()
+
   const [pickedCurrency, setPickedCurrency] = useState<string>()
   const [agreeWithTOS, setAgreeWithTOS] = useState(false)
 
   const triggerConfetti = useJsConfetti()
 
-  const [txHash, setTxHash] = useState("")
-  const [txError, setTxError] = useState(false)
-  const [txSuccess, setTxSuccess] = useState(false)
-
   useEffect(() => {
-    if (!txHash || !isOpen || isInfoModalOpen) return
+    if (!txHash || !isOpen || isTxModalOpen) return
     onClose()
-    onInfoModalOpen()
+    onTxModalOpen()
   }, [txHash])
 
   useEffect(() => {
@@ -75,19 +65,10 @@ const GuildCheckoutProvider = ({
         isOpen,
         onOpen,
         onClose,
-        isInfoModalOpen,
-        onInfoModalOpen,
-        onInfoModalClose,
         pickedCurrency,
         setPickedCurrency,
         agreeWithTOS,
         setAgreeWithTOS,
-        txHash,
-        setTxHash,
-        txSuccess,
-        setTxSuccess,
-        txError,
-        setTxError,
       }}
     >
       {children}
@@ -95,6 +76,17 @@ const GuildCheckoutProvider = ({
   )
 }
 
+const GuildCheckoutProviderWithWrapper = ({
+  children,
+}: PropsWithChildren<unknown>): JSX.Element => (
+  <TransactionStatusProvider>
+    <GuildCheckoutProvider>{children}</GuildCheckoutProvider>
+  </TransactionStatusProvider>
+)
+
 const useGuildCheckoutContext = () => useContext(GuildCheckoutContext)
 
-export { GuildCheckoutProvider, useGuildCheckoutContext }
+export {
+  GuildCheckoutProviderWithWrapper as GuildCheckoutProvider,
+  useGuildCheckoutContext,
+}

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex.tsx
@@ -8,14 +8,12 @@ import {
   useEffect,
   useState,
 } from "react"
-import { Requirement } from "types"
 import {
   TransactionStatusProvider,
   useTransactionStatusContext,
 } from "./TransactionStatusContext"
 
 export type GuildCheckoutContextType = {
-  requirement: Requirement
   isOpen: boolean
   onOpen: () => void
   onClose: () => void
@@ -30,11 +28,7 @@ const GuildCheckoutContext = createContext<GuildCheckoutContextType>(undefined)
 const GuildCheckoutProvider = ({
   children,
 }: PropsWithChildren<unknown>): JSX.Element => {
-  const requirement = useRequirementContext()
-  const { mutate: mutateAccess } = useAccess(requirement?.roleId)
-
-  const { isTxModalOpen, onTxModalOpen, txHash, txSuccess } =
-    useTransactionStatusContext()
+  const { isTxModalOpen, onTxModalOpen, txHash } = useTransactionStatusContext()
 
   const { isOpen, onOpen, onClose } = useDisclosure()
 

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/PaymentCurrencyPicker/PaymentCurrencyPicker.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/PaymentCurrencyPicker/PaymentCurrencyPicker.tsx
@@ -18,14 +18,15 @@ import { ArrowSquareOut, CaretDown } from "phosphor-react"
 import { useEffect } from "react"
 import { SUPPORTED_CURRENCIES } from "utils/guildCheckout/constants"
 import shortenHex from "utils/shortenHex"
+import { useRequirementContext } from "../../../RequirementContext"
 import usePrice from "../../hooks/usePrice"
 import { useGuildCheckoutContext } from "../GuildCheckoutContex"
 import CurrencyListItem from "./components/CurrencyListItem"
 import TokenInfo from "./components/TokenInfo"
 
 const PaymentCurrencyPicker = (): JSX.Element => {
-  const { requirement, pickedCurrency, setPickedCurrency } =
-    useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency, setPickedCurrency } = useGuildCheckoutContext()
 
   const circleBgColor = useColorModeValue("blackAlpha.100", "blackAlpha.300")
   const lightShade = useColorModeValue("white", "gray.700")

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/PaymentFeeCurrency.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/PaymentFeeCurrency.tsx
@@ -5,6 +5,7 @@ import useTokenData from "hooks/useTokenData"
 import { useEffect } from "react"
 import useVault from "requirements/Payment/hooks/useVault"
 import { NULL_ADDRESS } from "utils/guildCheckout/constants"
+import { useRequirementContext } from "../../RequirementContext"
 import { useGuildCheckoutContext } from "./GuildCheckoutContex"
 import TokenInfo from "./PaymentCurrencyPicker/components/TokenInfo"
 
@@ -12,8 +13,8 @@ const PaymentFeeCurrency = (): JSX.Element => {
   const lightShade = useColorModeValue("white", "gray.700")
   const borderWidth = useColorModeValue(1, 0)
 
-  const { requirement, pickedCurrency, setPickedCurrency } =
-    useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency, setPickedCurrency } = useGuildCheckoutContext()
 
   const {
     data: { token, fee },

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/PurchaseFeeAndTotal.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/PurchaseFeeAndTotal.tsx
@@ -4,6 +4,7 @@ import { RPC } from "connectors"
 import useTokenData from "hooks/useTokenData"
 import { Info, Question } from "phosphor-react"
 import { GUILD_FEE_PERCENTAGE } from "utils/guildCheckout/constants"
+import { useRequirementContext } from "../../RequirementContext"
 import usePrice from "../hooks/usePrice"
 import usePurchaseAsset from "../hooks/usePurchaseAsset"
 import FeesTable from "./FeesTable"
@@ -11,7 +12,8 @@ import { useGuildCheckoutContext } from "./GuildCheckoutContex"
 import PriceFallback from "./PriceFallback"
 
 const PurchaseFeeAndTotal = (): JSX.Element => {
-  const { pickedCurrency, requirement } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency } = useGuildCheckoutContext()
 
   const {
     data: { symbol },

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/PurchasedRequirementInfo.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/PurchasedRequirementInfo.tsx
@@ -8,7 +8,7 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import useTokenData from "hooks/useTokenData"
-import { useGuildCheckoutContext } from "./GuildCheckoutContex"
+import { useRequirementContext } from "../../RequirementContext"
 
 type Props = {
   rightElement?: JSX.Element
@@ -18,7 +18,8 @@ type Props = {
 const PurchasedRequirementInfo = ({ rightElement, footer }: Props): JSX.Element => {
   const circleBgColor = useColorModeValue("blackAlpha.100", "blackAlpha.300")
 
-  const { requirement } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+
   const {
     data: { symbol, logoURI },
   } = useTokenData(requirement?.chain, requirement?.address)

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusContext.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusContext.tsx
@@ -1,10 +1,12 @@
 import { useDisclosure } from "@chakra-ui/react"
+import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
 import {
   createContext,
   Dispatch,
   PropsWithChildren,
   SetStateAction,
   useContext,
+  useEffect,
   useState,
 } from "react"
 
@@ -32,6 +34,13 @@ const TransactionStatusProvider = ({
   const [txHash, setTxHash] = useState("")
   const [txError, setTxError] = useState(false)
   const [txSuccess, setTxSuccess] = useState(false)
+
+  const triggerConfetti = useJsConfetti()
+
+  useEffect(() => {
+    if (!txSuccess) return
+    triggerConfetti()
+  }, [txSuccess])
 
   return (
     <TransactionStatusContext.Provider

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusContext.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusContext.tsx
@@ -1,0 +1,57 @@
+import { useDisclosure } from "@chakra-ui/react"
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  useContext,
+  useState,
+} from "react"
+
+const TransactionStatusContext = createContext<{
+  isTxModalOpen: boolean
+  onTxModalOpen: () => void
+  onTxModalClose: () => void
+  txHash: string
+  setTxHash: Dispatch<SetStateAction<string>>
+  txError: boolean
+  setTxError: Dispatch<SetStateAction<boolean>>
+  txSuccess: boolean
+  setTxSuccess: Dispatch<SetStateAction<boolean>>
+}>(undefined)
+
+const TransactionStatusProvider = ({
+  children,
+}: PropsWithChildren<unknown>): JSX.Element => {
+  const {
+    isOpen: isTxModalOpen,
+    onOpen: onTxModalOpen,
+    onClose: onTxModalClose,
+  } = useDisclosure()
+
+  const [txHash, setTxHash] = useState("")
+  const [txError, setTxError] = useState(false)
+  const [txSuccess, setTxSuccess] = useState(false)
+
+  return (
+    <TransactionStatusContext.Provider
+      value={{
+        isTxModalOpen,
+        onTxModalOpen,
+        onTxModalClose,
+        txHash,
+        setTxHash,
+        txError,
+        setTxError,
+        txSuccess,
+        setTxSuccess,
+      }}
+    >
+      {children}
+    </TransactionStatusContext.Provider>
+  )
+}
+
+const useTransactionStatusContext = () => useContext(TransactionStatusContext)
+
+export { TransactionStatusProvider, useTransactionStatusContext }

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusModal/TransactionStatusModal.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusModal/TransactionStatusModal.tsx
@@ -5,7 +5,7 @@ import {
   ModalOverlay,
 } from "@chakra-ui/react"
 import { Modal } from "components/common/Modal"
-import { useGuildCheckoutContext } from "../GuildCheckoutContex"
+import { useTransactionStatusContext } from "../TransactionStatusContext"
 import TxError from "./components/TxError"
 import TxInProgress from "./components/TxInProgress"
 import TxSuccess from "./components/TxSuccess"
@@ -29,14 +29,11 @@ const TransactionStatusModal = ({
   successText,
   errorComponent,
 }: Props): JSX.Element => {
-  const { isInfoModalOpen, onInfoModalClose, txSuccess, txError, txHash } =
-    useGuildCheckoutContext()
+  const { isTxModalOpen, onTxModalClose, txSuccess, txError, txHash } =
+    useTransactionStatusContext()
 
   return (
-    <Modal
-      isOpen={isInfoModalOpen}
-      onClose={txSuccess ? onInfoModalClose : undefined}
-    >
+    <Modal isOpen={isTxModalOpen} onClose={txSuccess ? onTxModalClose : undefined}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusModal/components/TransactionLink.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusModal/components/TransactionLink.tsx
@@ -2,11 +2,11 @@ import { Icon, Link, Text } from "@chakra-ui/react"
 import { useWeb3React } from "@web3-react/core"
 import { Chains, RPC } from "connectors"
 import { ArrowSquareOut } from "phosphor-react"
-import { useGuildCheckoutContext } from "../../GuildCheckoutContex"
+import { useTransactionStatusContext } from "../../TransactionStatusContext"
 
 const TransactionLink = (): JSX.Element => {
   const { chainId } = useWeb3React()
-  const { txHash } = useGuildCheckoutContext()
+  const { txHash } = useTransactionStatusContext()
 
   return (
     <Text mb={6} colorScheme="gray">

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusModal/components/TransactionModalCloseButton.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusModal/components/TransactionModalCloseButton.tsx
@@ -1,11 +1,11 @@
 import Button from "components/common/Button"
-import { useGuildCheckoutContext } from "../../GuildCheckoutContex"
+import { useTransactionStatusContext } from "../../TransactionStatusContext"
 
 const TransactionModalCloseButton = (): JSX.Element => {
-  const { onInfoModalClose } = useGuildCheckoutContext()
+  const { onTxModalClose } = useTransactionStatusContext()
 
   return (
-    <Button size="lg" colorScheme={"blue"} w="full" onClick={onInfoModalClose}>
+    <Button size="lg" colorScheme="blue" w="full" onClick={onTxModalClose}>
       Close
     </Button>
   )

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/BuyAllowanceButton.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/BuyAllowanceButton.tsx
@@ -7,6 +7,7 @@ import { Chains, RPC } from "connectors"
 import useTokenData from "hooks/useTokenData"
 import { Check, Question, Warning } from "phosphor-react"
 import useVault from "requirements/Payment/hooks/useVault"
+import { useRequirementContext } from "../../../RequirementContext"
 import useAllowance from "../../hooks/useAllowance"
 import { useGuildCheckoutContext } from "../GuildCheckoutContex"
 
@@ -14,8 +15,9 @@ const BuyAllowanceButton = (): JSX.Element => {
   const { captureEvent } = usePostHogContext()
   const { urlName } = useGuild()
 
-  const { pickedCurrency, requirement } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
   const requirementChainId = Chains[requirement.chain]
+  const { pickedCurrency } = useGuildCheckoutContext()
 
   const { chainId } = useWeb3React()
 

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/BuyButton.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/BuyButton.tsx
@@ -1,13 +1,14 @@
 import { useWeb3React } from "@web3-react/core"
+import Button from "components/common/Button"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
-import Button from "components/common/Button"
 import { Chains, RPC } from "connectors"
 import useBalance from "hooks/useBalance"
 import useToast from "hooks/useToast"
 import useHasPaid from "requirements/Payment/hooks/useHasPaid"
 import useVault from "requirements/Payment/hooks/useVault"
 import fetcher from "utils/fetcher"
+import { useRequirementContext } from "../../../RequirementContext"
 import useAllowance from "../../hooks/useAllowance"
 import usePayFee from "../../hooks/usePayFee"
 import { useGuildCheckoutContext } from "../GuildCheckoutContex"
@@ -18,7 +19,9 @@ const BuyButton = (): JSX.Element => {
   const toast = useToast()
 
   const { chainId } = useWeb3React()
-  const { requirement, pickedCurrency, agreeWithTOS } = useGuildCheckoutContext()
+
+  const requirement = useRequirementContext()
+  const { pickedCurrency, agreeWithTOS } = useGuildCheckoutContext()
 
   const {
     data: { fee, multiplePayments },

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/PurchaseAllowanceButton.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/PurchaseAllowanceButton.tsx
@@ -8,6 +8,7 @@ import { usePostHogContext } from "components/_app/PostHogProvider"
 import { Chains, RPC } from "connectors"
 import useTokenData from "hooks/useTokenData"
 import { Check, Question, Warning } from "phosphor-react"
+import { useRequirementContext } from "../../../RequirementContext"
 import usePrice from "../../hooks/usePrice"
 import useTokenBuyerContractData from "../../hooks/useTokenBuyerContractData"
 import { useGuildCheckoutContext } from "../GuildCheckoutContex"
@@ -16,8 +17,9 @@ const PurchaseAllowanceButton = (): JSX.Element => {
   const { captureEvent } = usePostHogContext()
   const { urlName } = useGuild()
 
-  const { pickedCurrency, requirement } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
   const requirementChainId = Chains[requirement.chain]
+  const { pickedCurrency } = useGuildCheckoutContext()
 
   const { chainId } = useWeb3React()
 

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/PurchaseButton.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/PurchaseButton.tsx
@@ -5,6 +5,7 @@ import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import { Chains, RPC } from "connectors"
 import useBalance from "hooks/useBalance"
+import { useRequirementContext } from "../../../RequirementContext"
 import useAllowance from "../../hooks/useAllowance"
 import usePrice from "../../hooks/usePrice"
 import usePurchaseAsset from "../../hooks/usePurchaseAsset"
@@ -16,7 +17,9 @@ const PurchaseButton = (): JSX.Element => {
   const { urlName } = useGuild()
 
   const { account, chainId } = useWeb3React()
-  const { requirement, pickedCurrency, agreeWithTOS } = useGuildCheckoutContext()
+
+  const requirement = useRequirementContext()
+  const { pickedCurrency, agreeWithTOS } = useGuildCheckoutContext()
 
   const {
     data: { maxPriceInWei },

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/useAllowance.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/useAllowance.ts
@@ -7,7 +7,7 @@ import useSubmit from "hooks/useSubmit"
 import { useState } from "react"
 import ERC20_ABI from "static/abis/erc20Abi.json"
 import useSWR from "swr"
-import { useGuildCheckoutContext } from "../components/GuildCheckoutContex"
+import { useRequirementContext } from "../../RequirementContext"
 
 const fetchAllowance = ([_, account, contract, contractAddress]) =>
   contract?.allowance(account, contractAddress)
@@ -19,7 +19,7 @@ const useAllowance = (tokenAddress: string, contract: string) => {
   const { account, chainId } = useWeb3React()
   const erc20Contract = useContract(tokenAddress, ERC20_ABI, true)
 
-  const { requirement } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
 
   const shouldFetch =
     tokenAddress &&

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePayFee.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePayFee.ts
@@ -14,6 +14,7 @@ import FEE_COLLECTOR_ABI from "static/abis/feeCollectorAbi.json"
 import { mutate } from "swr"
 import { ADDRESS_REGEX, NULL_ADDRESS } from "utils/guildCheckout/constants"
 import processWalletError from "utils/processWalletError"
+import { useRequirementContext } from "../../RequirementContext"
 import { useGuildCheckoutContext } from "../components/GuildCheckoutContex"
 import useAllowance from "./useAllowance"
 import useSubmitTransaction from "./useSubmitTransaction"
@@ -67,7 +68,8 @@ const usePayFee = () => {
 
   const { chainId, account } = useWeb3React()
 
-  const { requirement, pickedCurrency } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency } = useGuildCheckoutContext()
 
   const feeCollectorContract = useContract(
     requirement.address,

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePrice.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePrice.ts
@@ -7,6 +7,7 @@ import {
   PURCHASABLE_REQUIREMENT_TYPES,
   purchaseSupportedChains,
 } from "utils/guildCheckout/constants"
+import { useRequirementContext } from "../../RequirementContext"
 import { useGuildCheckoutContext } from "../components/GuildCheckoutContex"
 
 const fetchPrice = ([
@@ -29,7 +30,9 @@ const fetchPrice = ([
 const usePrice = (sellAddress?: string): SWRResponse<FetchPriceResponse> => {
   const { account } = useWeb3React()
   const { id } = useGuild()
-  const { requirement, isOpen, pickedCurrency } = useGuildCheckoutContext()
+
+  const requirement = useRequirementContext()
+  const { isOpen, pickedCurrency } = useGuildCheckoutContext()
 
   const shouldFetch =
     purchaseSupportedChains[requirement?.type]?.includes(requirement?.chain) &&

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePurchaseAsset.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePurchaseAsset.ts
@@ -1,6 +1,7 @@
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber"
 import { Contract } from "@ethersproject/contracts"
 import { useWeb3React } from "@web3-react/core"
+import useAccess from "components/[guild]/hooks/useAccess"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import { Chains, RPC } from "connectors"
@@ -81,6 +82,7 @@ const usePurchaseAsset = () => {
   const { captureEvent } = usePostHogContext()
   const { id: guildId, urlName } = useGuild()
   const { requirement, pickedCurrency } = useGuildCheckoutContext()
+  const { mutate: mutateAccess } = useAccess(requirement?.roleId)
 
   const postHogOptions = { guild: urlName, chain: requirement.chain }
 
@@ -180,6 +182,8 @@ const usePurchaseAsset = () => {
         }
 
         captureEvent("Purchased requirement (GuildCheckout)", postHogOptions)
+
+        mutateAccess()
 
         toast({
           status: "success",

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePurchaseAsset.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePurchaseAsset.ts
@@ -18,6 +18,7 @@ import {
   generateGetAssetsParams,
 } from "utils/guildCheckout/utils"
 import processWalletError from "utils/processWalletError"
+import { useRequirementContext } from "../../RequirementContext"
 import { useGuildCheckoutContext } from "../components/GuildCheckoutContex"
 import useAllowance from "./useAllowance"
 import usePrice from "./usePrice"
@@ -81,7 +82,10 @@ const purchaseAsset = async (
 const usePurchaseAsset = () => {
   const { captureEvent } = usePostHogContext()
   const { id: guildId, urlName } = useGuild()
-  const { requirement, pickedCurrency } = useGuildCheckoutContext()
+
+  const requirement = useRequirementContext()
+  const { pickedCurrency } = useGuildCheckoutContext()
+
   const { mutate: mutateAccess } = useAccess(requirement?.roleId)
 
   const postHogOptions = { guild: urlName, chain: requirement.chain }

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/useSubmitTransaction.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/useSubmitTransaction.ts
@@ -1,14 +1,14 @@
 import { TransactionReceipt, TransactionResponse } from "@ethersproject/providers"
 import useSubmit, { UseSubmitOptions } from "hooks/useSubmit/useSubmit"
 import { Rest } from "types"
-import { useGuildCheckoutContext } from "../components/GuildCheckoutContex"
+import { useTransactionStatusContext } from "../components/TransactionStatusContext"
 
 const useSubmitTransaction = <DataType>(
   sendTransaction: (data?: DataType) => Promise<TransactionResponse>,
   { onSuccess, onError }: UseSubmitOptions<TransactionReceipt & Rest> = {}
 ) => {
   const { setTxHash, txHash, setTxError, setTxSuccess } =
-    useGuildCheckoutContext() ?? {}
+    useTransactionStatusContext() ?? {}
 
   const fetch = async (data?: DataType) => {
     const transaction = await sendTransaction(data)

--- a/src/components/[guild]/collect/components/RequirementsCard.tsx
+++ b/src/components/[guild]/collect/components/RequirementsCard.tsx
@@ -4,6 +4,7 @@ import CollectNftButton from "components/[guild]/collect/components/CollectNftBu
 import { useCollectNftContext } from "components/[guild]/collect/components/CollectNftContext"
 import LogicDivider from "components/[guild]/LogicDivider"
 import SwitchNetworkButton from "components/[guild]/Requirements/components/GuildCheckout/components/buttons/SwitchNetworkButton"
+import { TransactionStatusProvider } from "components/[guild]/Requirements/components/GuildCheckout/components/TransactionStatusContext"
 import RequirementDisplayComponent from "components/[guild]/Requirements/components/RequirementDisplayComponent"
 import { Chains } from "connectors"
 import { Logic, Requirement } from "types"
@@ -64,7 +65,9 @@ const RequirementsCard = ({ requirements, logic }: Props) => {
           {typeof alreadyCollected !== "undefined" && !alreadyCollected && (
             <SwitchNetworkButton targetChainId={Chains[chain]} />
           )}
-          <CollectNftButton label="Collect now" colorScheme="green" />
+          <TransactionStatusProvider>
+            <CollectNftButton label="Collect now" colorScheme="green" />
+          </TransactionStatusProvider>
         </Stack>
 
         {(data || isValidating) && (

--- a/src/requirements/PoapPayment/components/PoapBuyTotal.tsx
+++ b/src/requirements/PoapPayment/components/PoapBuyTotal.tsx
@@ -18,7 +18,6 @@ const PoapBuyTotal = (): JSX.Element => {
     vaultError: error,
   } = usePoapVault(requirement.data.id, Chains[requirement?.chain])
   const { token, fee } = vaultData
-  console.log(pickedCurrency, error, token)
 
   const {
     data: { decimals, symbol },

--- a/src/requirements/PoapPayment/components/PoapBuyTotal.tsx
+++ b/src/requirements/PoapPayment/components/PoapBuyTotal.tsx
@@ -3,6 +3,7 @@ import { formatUnits } from "@ethersproject/units"
 import usePoapVault from "components/[guild]/CreatePoap/hooks/usePoapVault"
 import { useGuildCheckoutContext } from "components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex"
 import PriceFallback from "components/[guild]/Requirements/components/GuildCheckout/components/PriceFallback"
+import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
 import { Chains } from "connectors"
 import useTokenData from "hooks/useTokenData"
 
@@ -11,7 +12,9 @@ import useTokenData from "hooks/useTokenData"
  * will switch to general payment requirement once POAP is a reward
  */
 const PoapBuyTotal = (): JSX.Element => {
-  const { requirement, pickedCurrency } = useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency } = useGuildCheckoutContext()
+
   const {
     vaultData,
     isVaultLoading: isValidating,

--- a/src/requirements/PoapPayment/components/PoapPaymentFeeCurrency.tsx
+++ b/src/requirements/PoapPayment/components/PoapPaymentFeeCurrency.tsx
@@ -19,11 +19,10 @@ const PoapPaymentFeeCurrency = (): JSX.Element => {
   const { requirement, pickedCurrency, setPickedCurrency } =
     useGuildCheckoutContext()
 
-  const {
-    vaultData,
-    isVaultLoading: isValidating,
-    vaultError: error,
-  } = usePoapVault(requirement?.data?.id, Chains[requirement?.chain])
+  const { vaultData, isVaultLoading: isValidating } = usePoapVault(
+    requirement?.data?.id,
+    Chains[requirement?.chain]
+  )
   const { token, fee } = vaultData
 
   const {

--- a/src/requirements/PoapPayment/components/PoapPaymentFeeCurrency.tsx
+++ b/src/requirements/PoapPayment/components/PoapPaymentFeeCurrency.tsx
@@ -3,6 +3,7 @@ import { formatUnits } from "@ethersproject/units"
 import usePoapVault from "components/[guild]/CreatePoap/hooks/usePoapVault"
 import { useGuildCheckoutContext } from "components/[guild]/Requirements/components/GuildCheckout/components/GuildCheckoutContex"
 import TokenInfo from "components/[guild]/Requirements/components/GuildCheckout/components/PaymentCurrencyPicker/components/TokenInfo"
+import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
 import { Chains, RPC } from "connectors"
 import useTokenData from "hooks/useTokenData"
 import { useEffect } from "react"
@@ -16,8 +17,8 @@ const PoapPaymentFeeCurrency = (): JSX.Element => {
   const lightShade = useColorModeValue("white", "gray.700")
   const borderWidth = useColorModeValue(1, 0)
 
-  const { requirement, pickedCurrency, setPickedCurrency } =
-    useGuildCheckoutContext()
+  const requirement = useRequirementContext()
+  const { pickedCurrency, setPickedCurrency } = useGuildCheckoutContext()
 
   const { vaultData, isVaultLoading: isValidating } = usePoapVault(
     requirement?.data?.id,


### PR DESCRIPTION
## Refactor

Made a `TransactionStatusContext` component, which includes the transaction state (txHash, txError, txSuccess) & `TransactionStatusModal` modal with its props (isOpen, onOpen, onClose). This refactor was required so we can use the `TransactionStatusModal` outside the Guild Checkout flow - e.g. on the Collect NFT page, I already added this modal there too, since it was a really small change after this refactor. The `useSubmitTransaction` hook also uses the state from this context, but it doesn't throw an error if we try to use it outside this context.

As a side quest, I also removed the `requirement` prop from the `GuildCheckoutContext`. It was originally included, since we only used this context for the requirement purchase flow, and that flow is only used inside a requirement context, so it made sense to just provide the requirement from this context, but this is not the case anymore.

Since we don't have E2E tests for these features (token purchase, buy pass, collect nft) yet, I tested them manually, just to make sure they still work with these new changes.
