### PR TITLE
Separate requests for contacts, admins and featureFlags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5143,6 +5143,36 @@
         "glob": "7.1.7"
       }
     },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
+      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
+      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "12.3.4",
       "cpu": [
@@ -5152,6 +5182,156 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz",
+      "integrity": "sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
+      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
+      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz",
+      "integrity": "sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz",
+      "integrity": "sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz",
+      "integrity": "sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz",
+      "integrity": "sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz",
+      "integrity": "sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz",
+      "integrity": "sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
+      "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -31399,186 +31579,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
-      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
-      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz",
-      "integrity": "sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
-      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
-      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz",
-      "integrity": "sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz",
-      "integrity": "sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz",
-      "integrity": "sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz",
-      "integrity": "sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz",
-      "integrity": "sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz",
-      "integrity": "sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
-      "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/src/components/[guild]/EditGuild/EditGuildDrawer.tsx
+++ b/src/components/[guild]/EditGuild/EditGuildDrawer.tsx
@@ -28,13 +28,13 @@ import useGuild from "components/[guild]/hooks/useGuild"
 import { useThemeContext } from "components/[guild]/ThemeContext"
 import usePinata from "hooks/usePinata"
 import useSubmitWithUpload from "hooks/useSubmitWithUpload"
-import useToast from "hooks/useToast"
 import useWarnIfUnsavedChanges from "hooks/useWarnIfUnsavedChanges"
 import dynamic from "next/dynamic"
 import { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { GuildFormType } from "types"
 import getRandomInt from "utils/getRandomInt"
+import handleSubmitDirty from "utils/handleSubmitDirty"
 import useGuildPermission from "../hooks/useGuildPermission"
 import useUser from "../hooks/useUser"
 import LeaveButton from "../LeaveButton"
@@ -112,17 +112,12 @@ const EditGuildDrawer = ({
     methods.setValue("contacts", contacts)
   }, [isDetailed])
 
-  const toast = useToast()
   const onSuccess = () => {
-    toast({
-      title: `Guild successfully updated!`,
-      status: "success",
-    })
     onClose()
     methods.reset(undefined, { keepValues: true })
   }
 
-  const { onSubmit, isLoading, isSigning, signLoadingText } = useEditGuild({
+  const { onSubmit, isLoading } = useEditGuild({
     onSuccess,
   })
 
@@ -184,15 +179,15 @@ const EditGuildDrawer = ({
 
   const { handleSubmit, isUploadingShown, uploadLoadingText } = useSubmitWithUpload(
     () => {
-      methods.handleSubmit((data) => {
+      handleSubmitDirty(methods)((data) => {
         onSubmit({ ...data, tags: undefined })
-        onTagsSubmit(data.tags)
+        if (data.tags) onTagsSubmit(data.tags)
       })()
     },
     backgroundUploader.isUploading || iconUploader.isUploading
   )
 
-  const loadingText = signLoadingText || uploadLoadingText || "Saving data"
+  const loadingText = uploadLoadingText || "Saving data"
 
   const isDirty =
     !!Object.keys(methods.formState.dirtyFields).length ||
@@ -291,7 +286,7 @@ const EditGuildDrawer = ({
               </Button>
               <Button
                 // isDisabled={!isDirty}
-                isLoading={isLoading || isSigning || isUploadingShown}
+                isLoading={isLoading || isUploadingShown}
                 colorScheme="green"
                 loadingText={loadingText}
                 onClick={handleSubmit}

--- a/src/components/[guild]/EditGuild/components/Admins/Admins.tsx
+++ b/src/components/[guild]/EditGuild/components/Admins/Admins.tsx
@@ -148,20 +148,9 @@ const Admins = () => {
           onBlur={onBlur}
           onChange={(selectedOption: SelectOption[]) => {
             onChange(
-              selectedOption?.map((option) => {
-                const prevAdmin = admins?.find(
-                  ({ address }) =>
-                    address?.toLowerCase() === option.value.toLowerCase()
-                )
-
-                if (prevAdmin) {
-                  return prevAdmin
-                }
-
-                return {
-                  address: option.value.toLowerCase(),
-                }
-              })
+              selectedOption?.map((option) => ({
+                address: option.value.toLowerCase(),
+              }))
             )
           }}
           isLoading={isLoading}

--- a/src/components/[guild]/EditGuild/components/Admins/Admins.tsx
+++ b/src/components/[guild]/EditGuild/components/Admins/Admins.tsx
@@ -148,9 +148,20 @@ const Admins = () => {
           onBlur={onBlur}
           onChange={(selectedOption: SelectOption[]) => {
             onChange(
-              selectedOption?.map((option) => ({
-                address: option.value.toLowerCase(),
-              }))
+              selectedOption?.map((option) => {
+                const prevAdmin = admins?.find(
+                  ({ address }) =>
+                    address?.toLowerCase() === option.value.toLowerCase()
+                )
+
+                if (prevAdmin) {
+                  return prevAdmin
+                }
+
+                return {
+                  address: option.value.toLowerCase(),
+                }
+              })
             )
           }}
           isLoading={isLoading}

--- a/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
+++ b/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
@@ -32,11 +32,21 @@ const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {
     const existingAdmins = guild?.admins ?? []
     const { admins = [], featureFlags = [], contacts = [], ...guildData } = data
 
-    const adminsToCreate = admins.filter((admin) => !admin.id)
+    const adminsToCreate = admins.filter(
+      (admin) =>
+        !existingAdmins.some(
+          (existingAdmin) =>
+            existingAdmin.address?.toLowerCase() === admin.address?.toLowerCase()
+        )
+    )
+
     const adminsToDelete = existingAdmins.filter(
       (existingAdmin) =>
         !existingAdmin?.isOwner &&
-        !admins.some((admin) => admin.id === existingAdmin.id)
+        !admins.some(
+          (admin) =>
+            existingAdmin.address?.toLowerCase() === admin.address?.toLowerCase()
+        )
     )
 
     const contactsToUpdate = contacts.filter((contact) => {

--- a/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
+++ b/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
@@ -1,15 +1,19 @@
 import useGuild from "components/[guild]/hooks/useGuild"
 import useMatchMutate from "hooks/useMatchMutate"
 import useShowErrorToast from "hooks/useShowErrorToast"
-import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
+import useSubmit from "hooks/useSubmit"
+import useToast from "hooks/useToast"
 import { useRouter } from "next/router"
-import fetcher from "utils/fetcher"
+import { GuildFormType } from "types"
+import { useFetcherWithSign } from "utils/fetcher"
 import replacer from "utils/guildJsonReplacer"
 
 type Props = {
   onSuccess?: () => void
   guildId?: string | number
 }
+
+const countFalsy = <Item>(arr: Array<Item>) => arr.filter((req) => !req).length
 
 const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {
   const guild = useGuild(guildId)
@@ -18,27 +22,299 @@ const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {
 
   const showErrorToast = useShowErrorToast()
   const router = useRouter()
+  const fetcherWithSign = useFetcherWithSign()
 
   const id = guildId ?? guild?.id
 
-  const submit = (signedValidation: SignedValdation) =>
-    fetcher(`/v2/guilds/${id}`, {
-      method: "PUT",
-      ...signedValidation,
-    })
+  const submit = async (data: GuildFormType) => {
+    const existingFeatureFlags = guild?.featureFlags ?? []
+    const existingContacts = guild?.contacts ?? []
+    const existingAdmins = guild?.admins ?? []
+    const { admins = [], featureFlags = [], contacts = [], ...guildData } = data
 
-  const useSubmitResponse = useSubmitWithSign<any>(submit, {
-    forcePrompt: true,
-    onSuccess: (newGuild) => {
+    const adminsToCreate = admins.filter((admin) => !admin.id)
+    const adminsToDelete = existingAdmins.filter(
+      (existingAdmin) =>
+        !existingAdmin?.isOwner &&
+        !admins.some((admin) => admin.id === existingAdmin.id)
+    )
+
+    const contactsToUpdate = contacts.filter((contact) => {
+      if (!contact.id) return false
+      const prevContact = existingContacts?.find((ec) => ec.id === contact.id)
+      if (!prevContact) return false
+      return (
+        !!contact.id &&
+        !(
+          contact.id === prevContact.id &&
+          contact.contact === prevContact.contact &&
+          contact.type === prevContact.type
+        )
+      )
+    })
+    const contactsToCreate = contacts.filter((contact) => !contact.id)
+    const contactsToDelete = existingContacts.filter(
+      (existingContact) =>
+        !contacts.some((contact) => contact.id === existingContact.id)
+    )
+
+    const featureFlagsToCreate = featureFlags.filter(
+      (flag) => !existingFeatureFlags.includes(flag)
+    )
+    const featureFlagsToDelete = existingFeatureFlags.filter(
+      (existingFlag) => !featureFlags.includes(existingFlag)
+    )
+
+    const shouldUpdateBaseGuild = guildData && Object.keys(guildData).length > 0
+
+    const adminCreations = Promise.all(
+      adminsToCreate.map((adminToCreate) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/admins`,
+          { method: "POST", body: adminToCreate },
+        ]).catch(() => null)
+      )
+    )
+
+    const adminDeletions = Promise.all(
+      adminsToDelete.map((adminToDelete) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/admins/${adminToDelete.id}`,
+          { method: "DELETE" },
+        ])
+          .then(() => ({ id: adminToDelete.id }))
+          .catch(() => null)
+      )
+    )
+
+    const contactCreations = Promise.all(
+      contactsToCreate.map((contactToCreate) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/contacts`,
+          { method: "POST", body: contactToCreate },
+        ]).catch(() => null)
+      )
+    )
+
+    const contactUpdates = Promise.all(
+      contactsToUpdate.map((contactToUpdate) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/contacts/${contactToUpdate.id}`,
+          { method: "PUT", body: contactToUpdate },
+        ]).catch(() => null)
+      )
+    )
+
+    const contactDeletions = Promise.all(
+      contactsToDelete.map((contactToDelete) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/contacts/${contactToDelete.id}`,
+          { method: "DELETE" },
+        ])
+          .then(() => ({ id: contactToDelete.id }))
+          .catch(() => null)
+      )
+    )
+
+    const featureFlagCreations = Promise.all(
+      featureFlagsToCreate.map((featureFlagToCreate) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/feature-flags`,
+          { method: "POST", body: { featureType: featureFlagToCreate } },
+        ]).catch(() => null)
+      )
+    )
+
+    const featureFlagDeletions = Promise.all(
+      featureFlagsToDelete.map((featureFlagToDelete) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/feature-flags/${featureFlagToDelete}`,
+          { method: "DELETE" },
+        ])
+          .then(() => ({ flagType: featureFlagToDelete }))
+          .catch(() => null)
+      )
+    )
+
+    const baseGuildUpdate = shouldUpdateBaseGuild
+      ? fetcherWithSign([
+          `/v2/guilds/${id}`,
+          { method: "PUT", body: guildData },
+        ]).catch(() => null)
+      : new Promise<void>((resolve) => resolve())
+
+    const [
+      adminCreationResults,
+      adminDeleteResults,
+      contactCreationResults,
+      contactUpdateResults,
+      contactDeleteResults,
+      featureFlagCreationResults,
+      featureFlagDeletionResults,
+      guildUpdateResult,
+    ] = await Promise.all([
+      adminCreations,
+      adminDeletions,
+      contactCreations,
+      contactUpdates,
+      contactDeletions,
+      featureFlagCreations,
+      featureFlagDeletions,
+      baseGuildUpdate,
+    ])
+
+    return {
+      admin: {
+        creations: {
+          success: adminCreationResults.filter(Boolean),
+          failedCount: countFalsy(adminCreationResults),
+        },
+        deletions: {
+          success: adminDeleteResults.filter(Boolean),
+          failedCount: countFalsy(adminDeleteResults),
+        },
+      },
+
+      contacts: {
+        creations: {
+          success: contactCreationResults.filter(Boolean),
+          failedCount: countFalsy(contactCreationResults),
+        },
+        updates: {
+          success: contactUpdateResults.filter(Boolean),
+          failedCount: countFalsy(contactUpdateResults),
+        },
+        deletions: {
+          success: contactDeleteResults.filter(Boolean),
+          failedCount: countFalsy(contactDeleteResults),
+        },
+      },
+
+      featureFlags: {
+        creations: {
+          success: featureFlagCreationResults.filter(Boolean),
+          failedCount: countFalsy(featureFlagCreationResults),
+        },
+        deletions: {
+          success: featureFlagDeletionResults.filter(Boolean),
+          failedCount: countFalsy(featureFlagDeletionResults),
+        },
+      },
+
+      guildUpdateResult,
+    } as const
+  }
+
+  const toast = useToast()
+
+  const useSubmitResponse = useSubmit(submit, {
+    onSuccess: ({ admin, contacts, featureFlags, guildUpdateResult }) => {
       if (onSuccess) onSuccess()
-      guild.mutateGuild((prev) => ({ ...prev, ...newGuild }), {
-        revalidate: false,
-      })
+
+      // Show success / error toasts
+      if (
+        admin.creations.failedCount <= 0 &&
+        admin.deletions.failedCount <= 0 &&
+        contacts.creations.failedCount <= 0 &&
+        contacts.updates.failedCount <= 0 &&
+        contacts.deletions.failedCount <= 0 &&
+        featureFlags.creations.failedCount <= 0 &&
+        featureFlags.deletions.failedCount <= 0 &&
+        !guildUpdateResult
+      ) {
+        toast({
+          title: `Guild successfully updated!`,
+          status: "success",
+        })
+      } else {
+        if (admin.creations.failedCount > 0) {
+          showErrorToast("Failed to create some admins")
+        }
+        if (admin.deletions.failedCount > 0) {
+          showErrorToast("Failed to delete some admins")
+        }
+
+        if (contacts.creations.failedCount > 0) {
+          showErrorToast("Failed to create some contacts")
+        }
+        if (contacts.updates.failedCount > 0) {
+          showErrorToast("Failed to update some contacts")
+        }
+        if (contacts.deletions.failedCount > 0) {
+          showErrorToast("Failed to delete some contacts")
+        }
+
+        if (featureFlags.creations.failedCount > 0) {
+          showErrorToast("Failed to create some feature flags")
+        }
+        if (featureFlags.deletions.failedCount > 0) {
+          showErrorToast("Failed to delete some feature flags")
+        }
+
+        if (guildUpdateResult === null) {
+          showErrorToast("Failed to update guild data")
+        }
+      }
+
+      guild.mutateGuild(
+        (prev) => {
+          const oldAdminsThatHaventBeenDeleted = (prev.admins ?? []).filter(
+            (prevAdmin) =>
+              !admin.deletions.success.some(
+                (deletedAdmin) => deletedAdmin.id === prevAdmin.id
+              )
+          )
+
+          const oldContactsThatHaventBeenDeletedNorUpdated = (
+            prev.contacts ?? []
+          ).filter(
+            (prevContact) =>
+              !contacts.deletions.success.some(
+                (deletedContact) => deletedContact.id === prevContact.id
+              ) &&
+              !contacts.updates.success.some(
+                (updatedContact) => updatedContact.id === prevContact.id
+              )
+          )
+
+          const oldFeatureFlagsThatHaventBeenDeleted = (
+            prev.featureFlags ?? []
+          ).filter(
+            (prevFeatureFlag) =>
+              !featureFlags.deletions.success.some(
+                (deletedFlag) => deletedFlag.featureType === prevFeatureFlag
+              )
+          )
+
+          return {
+            ...prev,
+            ...(guildUpdateResult ?? {}),
+            admins: [...oldAdminsThatHaventBeenDeleted, ...admin.creations.success],
+            contacts: [
+              ...oldContactsThatHaventBeenDeletedNorUpdated,
+              ...contacts.updates.success,
+              ...contacts.creations.success,
+            ],
+            featureFlags: [
+              ...oldFeatureFlagsThatHaventBeenDeleted,
+              featureFlags.creations.success.map(
+                (createdFlag) => createdFlag.featureType
+              ),
+            ],
+          }
+        },
+        {
+          revalidate: false,
+        }
+      )
 
       matchMutate(/^\/guild\/address\//)
       matchMutate(/^\/guild\?order/)
-      if (newGuild?.urlName && newGuild.urlName !== guild?.urlName) {
-        router.push(newGuild.urlName)
+      if (
+        guildUpdateResult?.urlName &&
+        guildUpdateResult.urlName !== guild?.urlName
+      ) {
+        router.push(guildUpdateResult.urlName)
       }
     },
     onError: (err) => showErrorToast(err),

--- a/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
+++ b/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
@@ -30,50 +30,62 @@ const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {
     const existingFeatureFlags = guild?.featureFlags ?? []
     const existingContacts = guild?.contacts ?? []
     const existingAdmins = guild?.admins ?? []
-    const { admins = [], featureFlags = [], contacts = [], ...guildData } = data
+    const { admins, featureFlags, contacts, ...guildData } = data
 
-    const adminsToCreate = admins.filter(
-      (admin) =>
-        !existingAdmins.some(
-          (existingAdmin) =>
-            existingAdmin.address?.toLowerCase() === admin.address?.toLowerCase()
-        )
-    )
-
-    const adminsToDelete = existingAdmins.filter(
-      (existingAdmin) =>
-        !existingAdmin?.isOwner &&
-        !admins.some(
+    const adminsToCreate = admins
+      ? admins.filter(
           (admin) =>
-            existingAdmin.address?.toLowerCase() === admin.address?.toLowerCase()
+            !existingAdmins.some(
+              (existingAdmin) =>
+                existingAdmin.address?.toLowerCase() === admin.address?.toLowerCase()
+            )
         )
-    )
+      : []
 
-    const contactsToUpdate = contacts.filter((contact) => {
-      if (!contact.id) return false
-      const prevContact = existingContacts?.find((ec) => ec.id === contact.id)
-      if (!prevContact) return false
-      return (
-        !!contact.id &&
-        !(
-          contact.id === prevContact.id &&
-          contact.contact === prevContact.contact &&
-          contact.type === prevContact.type
+    const adminsToDelete = admins
+      ? existingAdmins.filter(
+          (existingAdmin) =>
+            !existingAdmin?.isOwner &&
+            !admins.some(
+              (admin) =>
+                existingAdmin.address?.toLowerCase() === admin.address?.toLowerCase()
+            )
         )
-      )
-    })
-    const contactsToCreate = contacts.filter((contact) => !contact.id)
-    const contactsToDelete = existingContacts.filter(
-      (existingContact) =>
-        !contacts.some((contact) => contact.id === existingContact.id)
-    )
+      : []
 
-    const featureFlagsToCreate = featureFlags.filter(
-      (flag) => !existingFeatureFlags.includes(flag)
-    )
-    const featureFlagsToDelete = existingFeatureFlags.filter(
-      (existingFlag) => !featureFlags.includes(existingFlag)
-    )
+    const contactsToUpdate = contacts
+      ? contacts.filter((contact) => {
+          if (!contact.id) return false
+          const prevContact = existingContacts?.find((ec) => ec.id === contact.id)
+          if (!prevContact) return false
+          return (
+            !!contact.id &&
+            !(
+              contact.id === prevContact.id &&
+              contact.contact === prevContact.contact &&
+              contact.type === prevContact.type
+            )
+          )
+        })
+      : []
+    const contactsToCreate = contacts
+      ? contacts.filter((contact) => !contact.id)
+      : []
+    const contactsToDelete = contacts
+      ? existingContacts.filter(
+          (existingContact) =>
+            !contacts.some((contact) => contact.id === existingContact.id)
+        )
+      : []
+
+    const featureFlagsToCreate = featureFlags
+      ? featureFlags.filter((flag) => !existingFeatureFlags.includes(flag))
+      : []
+    const featureFlagsToDelete = featureFlags
+      ? existingFeatureFlags.filter(
+          (existingFlag) => !featureFlags.includes(existingFlag)
+        )
+      : []
 
     const shouldUpdateBaseGuild = guildData && Object.keys(guildData).length > 0
 
@@ -230,7 +242,7 @@ const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {
         contacts.deletions.failedCount <= 0 &&
         featureFlags.creations.failedCount <= 0 &&
         featureFlags.deletions.failedCount <= 0 &&
-        !guildUpdateResult
+        guildUpdateResult
       ) {
         toast({
           title: `Guild successfully updated!`,
@@ -307,7 +319,7 @@ const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {
             ],
             featureFlags: [
               ...oldFeatureFlagsThatHaventBeenDeleted,
-              featureFlags.creations.success.map(
+              ...featureFlags.creations.success.map(
                 (createdFlag) => createdFlag.featureType
               ),
             ],

--- a/src/components/[guild]/Onboarding/components/SummonMembers/SummonMembers.tsx
+++ b/src/components/[guild]/Onboarding/components/SummonMembers/SummonMembers.tsx
@@ -88,7 +88,7 @@ const SummonMembers = ({ activeStep, prevStep, nextStep: _ }: Props) => {
         prevStep={prevStep}
         nextStep={handleFinish}
         nextLabel="Finish"
-        nextLoading={isLoading || response}
+        nextLoading={isLoading || !!response}
       />
       {discordPlatform && (
         <>

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,6 +325,7 @@ type GuildTags = (typeof guildTags)[number]
 type GuildContact = {
   type: "EMAIL" | "TELEGRAM"
   contact: string
+  id?: number
 }
 
 type Guild = {
@@ -378,6 +379,11 @@ type GuildFormType = Partial<
   logic?: Logic
   requirements?: Requirement[]
   socialLinks?: Record<string, string>
+  admins?: Array<{
+    address: string
+    id?: number
+    isOwner?: boolean
+  }>
 }
 
 type SelectOption<T = string> = {

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -103,7 +103,7 @@ const fetcherWithSign = async (
     forcePrompt?: boolean
   },
   resource: string,
-  { body, ...rest }: Record<string, any> = {}
+  { body = {}, ...rest }: Record<string, any> = {}
 ) => {
   const [signedPayload, validation] = await sign({
     forcePrompt: false,

--- a/src/utils/handleSubmitDirty.ts
+++ b/src/utils/handleSubmitDirty.ts
@@ -15,6 +15,11 @@ const DIRTY_KEYS_TO_KEEP = [
 const KEYS_TO_KEEP = [
   // There's a chance that we send empty arrays intentionally e.g. inside a contract call's guildPlatformData
   "argsToSign",
+
+  // These are processed into creates/updates/deletes in a useSubmit's fetcher. Therefore we need all of them to know if we need to delete some. Otherwise we couldn't tell if something needs to be deleted, or just hasn't been changed
+  "admins",
+  "contacts",
+  "featureFlags",
 ]
 
 /**
@@ -30,6 +35,10 @@ const KEYS_TO_KEEP = [
  * @returns A new object, that is a subset of formData based on dirtyFields
  */
 const formDataFilterForDirtyHelper = (dirtyFields: any, formData: any) => {
+  if (!formData) {
+    return TO_FILTER_FLAG
+  }
+
   if (Array.isArray(dirtyFields)) {
     const newArr = dirtyFields
       .map((field, index) => formDataFilterForDirtyHelper(field, formData[index]))

--- a/src/utils/handleSubmitDirty.ts
+++ b/src/utils/handleSubmitDirty.ts
@@ -20,6 +20,7 @@ const KEYS_TO_KEEP = [
   "admins",
   "contacts",
   "featureFlags",
+  "socialLinks",
 ]
 
 /**


### PR DESCRIPTION
## Feature

### General details
- Linear issue: https://linear.app/guildxyz/issue/GUILD-1066/fe-for-new-entities
- Discord thread: https://discord.com/channels/697041998728659035/1086006153365954600

### Core implementation details

- Guild edit now uses `handleSubmitDirty`
  - Because of this, I had to include the `if (data.tags)` condition
- `useEditGuild`: Similarly to the hook for roles, it now separates contact, admin, and featureFlag requests from the main guild update request. It became massive, we might be able to abstract some of the logic away, but I'm not sure if it is important now
- `handleSubmitDirty` had to be tweaked once again :harold: The reason is that we only send the requests once the user hits save (we don't send an admin deletion immediately when the user presses the delete button. We could, lmk, if it should work that way, for now I just replicated the current functionality), so we need all the data to know if something needs to be deleted, or it is just not modified
  - The extra condition inside the function is needed, because in the case of contact deletion, the contact object is deleted from formData, but it is kept in dirtyValues :cannot_be_undone:

### How to run locally

- Run the app as you normally would

### Deployment checklist

As described in https://github.com/agoraxyz/guild-backend/pull/1007