### PR TITLE
fix: put `addressLinkParams` in its own context

### DIFF
--- a/src/components/_app/AddressLinkProvider.tsx
+++ b/src/components/_app/AddressLinkProvider.tsx
@@ -1,0 +1,31 @@
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  SetStateAction,
+  useContext,
+  useState,
+} from "react"
+
+type State = { userId: number | null; address: string }
+
+const AddressLinkContext = createContext<{
+  addressLinkParams: State
+  setAddressLinkParams: Dispatch<SetStateAction<State>>
+}>(undefined)
+
+const AddressLinkProvider = ({
+  children,
+}: PropsWithChildren<unknown>): JSX.Element => {
+  const [addressLinkParams, setAddressLinkParams] = useState<State>()
+
+  return (
+    <AddressLinkContext.Provider value={{ addressLinkParams, setAddressLinkParams }}>
+      {children}
+    </AddressLinkContext.Provider>
+  )
+}
+
+const useAddressLinkContext = () => useContext(AddressLinkContext)
+
+export { AddressLinkProvider, useAddressLinkContext }

--- a/src/components/_app/KeyPairProvider.tsx
+++ b/src/components/_app/KeyPairProvider.tsx
@@ -4,7 +4,7 @@ import { usePostHogContext } from "components/_app/PostHogProvider"
 import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import { randomBytes } from "crypto"
 import { createStore, del, get, set } from "idb-keyval"
-import { PropsWithChildren, createContext, useContext, useEffect } from "react"
+import { createContext, PropsWithChildren, useContext, useEffect } from "react"
 import useSWR, { KeyedMutator, mutate, unstable_serialize } from "swr"
 import useSWRImmutable from "swr/immutable"
 import { AddressConnectionProvider, User } from "types"
@@ -15,6 +15,7 @@ import {
   useSubmitWithSignWithParamKeyPair,
 } from "../../hooks/useSubmit/useSubmit"
 import useToast from "../../hooks/useToast"
+import { useAddressLinkContext } from "./AddressLinkProvider"
 
 type StoredKeyPair = {
   keyPair: CryptoKeyPair
@@ -206,12 +207,9 @@ const KeyPairProvider = ({ children }: PropsWithChildren<unknown>): JSX.Element 
 
   const { account } = useWeb3React()
 
-  const {
-    isDelegateConnection,
-    setIsDelegateConnection,
-    addressLinkParams,
-    setAddressLinkParams,
-  } = useWeb3ConnectionManager()
+  const { addressLinkParams, setAddressLinkParams } = useAddressLinkContext()
+  const { isDelegateConnection, setIsDelegateConnection } =
+    useWeb3ConnectionManager()
 
   const {
     id,

--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -4,13 +4,13 @@ import { useWeb3React } from "@web3-react/core"
 import { WalletConnect } from "@web3-react/walletconnect-v2"
 import NetworkModal from "components/common/Layout/components/Account/components/NetworkModal/NetworkModal"
 import requestNetworkChangeHandler from "components/common/Layout/components/Account/components/NetworkModal/utils/requestNetworkChange"
-import { Chains, RPC, getConnectorName } from "connectors"
+import { Chains, getConnectorName, RPC } from "connectors"
 import useContractWalletInfoToast from "hooks/useContractWalletInfoToast"
 import useToast from "hooks/useToast"
 import { useRouter } from "next/router"
 import {
-  PropsWithChildren,
   createContext,
+  PropsWithChildren,
   useContext,
   useEffect,
   useState,
@@ -44,8 +44,6 @@ const Web3Connection = createContext({
     _addressOrDomain: string,
     _platformName: PlatformName
   ) => {},
-  addressLinkParams: { userId: null as number, address: "" },
-  setAddressLinkParams: (_: { userId: number; address: string }) => {},
 })
 
 const Web3ConnectionManager = ({
@@ -86,10 +84,6 @@ const Web3ConnectionManager = ({
   const [accountMergeAddress, setAccountMergeAddress] = useState<string>("")
   const [accountMergePlatformName, setAccountMergePlatformName] =
     useState<PlatformName>()
-  const [addressLinkParams, setAddressLinkParams] = useState<{
-    userId: number
-    address: string
-  }>()
 
   const [isDelegateConnection, setIsDelegateConnection] = useState<boolean>(false)
 
@@ -154,8 +148,6 @@ const Web3ConnectionManager = ({
         isDelegateConnection,
         setIsDelegateConnection,
         isNetworkChangeInProgress,
-        addressLinkParams,
-        setAddressLinkParams,
       }}
     >
       {children}

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/hooks/useShouldLinkToUser.ts
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/hooks/useShouldLinkToUser.ts
@@ -1,10 +1,10 @@
 import { useUserPublic } from "components/[guild]/hooks/useUser"
+import { useAddressLinkContext } from "components/_app/AddressLinkProvider"
 import {
   deleteKeyPairFromIdb,
   getKeyPairFromIdb,
 } from "components/_app/KeyPairProvider"
 import useSWR, { mutate, unstable_serialize } from "swr"
-import { useWeb3ConnectionManager } from "../../../Web3ConnectionManager"
 
 const fetchShouldLinkToUser = async ([_, userId, connectParams]) => {
   const { userId: userIdToConnectTo } = connectParams ?? {}
@@ -29,7 +29,7 @@ const fetchShouldLinkToUser = async ([_, userId, connectParams]) => {
 
 const useShouldLinkToUser = () => {
   const { id } = useUserPublic()
-  const { setAddressLinkParams, addressLinkParams } = useWeb3ConnectionManager()
+  const { setAddressLinkParams, addressLinkParams } = useAddressLinkContext()
 
   const { data: shouldLinkToUser } = useSWR(
     addressLinkParams?.userId ? ["shouldLinkToUser", id, addressLinkParams] : null,

--- a/src/components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton.tsx
@@ -10,11 +10,12 @@ import {
 } from "@chakra-ui/react"
 import { Web3Provider } from "@ethersproject/providers"
 import { useWeb3React } from "@web3-react/core"
-import LogicDivider from "components/[guild]/LogicDivider"
-import useUser from "components/[guild]/hooks/useUser"
-import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import Button from "components/common/Button"
 import { Modal } from "components/common/Modal"
+import useUser from "components/[guild]/hooks/useUser"
+import LogicDivider from "components/[guild]/LogicDivider"
+import { useAddressLinkContext } from "components/_app/AddressLinkProvider"
+import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import { Plus, SignOut } from "phosphor-react"
 import { useState } from "react"
 
@@ -23,8 +24,8 @@ const LinkAddressButton = (props) => {
   const { id } = useUser()
   const { provider, connector, account } = useWeb3React<Web3Provider>()
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const { openWalletSelectorModal, setAddressLinkParams } =
-    useWeb3ConnectionManager()
+  const { setAddressLinkParams } = useAddressLinkContext()
+  const { openWalletSelectorModal } = useWeb3ConnectionManager()
 
   if (!id) return null
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,13 @@
 import { Box, Progress, Slide, useColorMode } from "@chakra-ui/react"
 import { Web3ReactProvider } from "@web3-react/core"
+import AccountModal from "components/common/Layout/components/Account/components/AccountModal"
+import { AddressLinkProvider } from "components/_app/AddressLinkProvider"
 import Chakra from "components/_app/Chakra"
 import ExplorerProvider from "components/_app/ExplorerProvider"
 import IntercomProvider from "components/_app/IntercomProvider"
 import { KeyPairProvider } from "components/_app/KeyPairProvider"
 import { PostHogProvider } from "components/_app/PostHogProvider"
 import { Web3ConnectionManager } from "components/_app/Web3ConnectionManager"
-import AccountModal from "components/common/Layout/components/Account/components/AccountModal"
 import { connectors } from "connectors"
 import type { AppProps } from "next/app"
 import { useRouter } from "next/router"
@@ -78,16 +79,18 @@ const App = ({
           <SWRConfig value={{ fetcher: fetcherForSWR }}>
             <Web3ReactProvider connectors={connectors}>
               <PostHogProvider>
-                <KeyPairProvider>
-                  <Web3ConnectionManager>
-                    <IntercomProvider>
-                      <ExplorerProvider>
-                        <Component {...pageProps} />
-                        <AccountModal />
-                      </ExplorerProvider>
-                    </IntercomProvider>
-                  </Web3ConnectionManager>
-                </KeyPairProvider>
+                <AddressLinkProvider>
+                  <KeyPairProvider>
+                    <Web3ConnectionManager>
+                      <IntercomProvider>
+                        <ExplorerProvider>
+                          <Component {...pageProps} />
+                          <AccountModal />
+                        </ExplorerProvider>
+                      </IntercomProvider>
+                    </Web3ConnectionManager>
+                  </KeyPairProvider>
+                </AddressLinkProvider>
               </PostHogProvider>
             </Web3ReactProvider>
           </SWRConfig>


### PR DESCRIPTION
## Bugfix

### Describe the bug

Users currently can't link new addresses to their current profile,  because it seems like properties inside `addressLinkParams` are not defined. It happens because we store these values inside `Web3ConnectionManager`, but we use them in `KeyPairProvider`, which is **not** wrapped inside the connection manager provider.

### Steps to reproduce

1. Connect your wallet to Guild.xyz
2. Open the account modal, and click on "+ Link address"
3. Try linking another wallet address
4. It just won't work (we don't show an error toast, or anything else)

### How this PR solves the issue

I extracted the `addressLinkParams` state in its own context and moved it above `KeyPairProvider`. 

 