### PR TITLE
fix: add userId to generatedKeyPair SWR key

### DIFF
--- a/src/components/_app/KeyPairProvider.tsx
+++ b/src/components/_app/KeyPairProvider.tsx
@@ -4,7 +4,7 @@ import { usePostHogContext } from "components/_app/PostHogProvider"
 import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import { randomBytes } from "crypto"
 import { createStore, del, get, set } from "idb-keyval"
-import { PropsWithChildren, createContext, useContext, useEffect } from "react"
+import { createContext, PropsWithChildren, useContext, useEffect } from "react"
 import useSWR, { KeyedMutator, mutate, unstable_serialize } from "swr"
 import useSWRImmutable from "swr/immutable"
 import { AddressConnectionProvider, User } from "types"
@@ -241,12 +241,8 @@ const KeyPairProvider = ({ children }: PropsWithChildren<unknown>): JSX.Element 
   })
 
   const { data: generatedKeyPair } = useSWRImmutable(
-    "generatedKeyPair",
-    generateKeyPair,
-    {
-      revalidateOnMount: true,
-      fallbackData: { pubKey: undefined, keyPair: undefined },
-    }
+    ["generatedKeyPair", id],
+    generateKeyPair
   )
 
   const toast = useToast()

--- a/src/components/common/Layout/components/Account/components/AccountModal/AccountModal.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/AccountModal.tsx
@@ -18,12 +18,12 @@ import { CoinbaseWallet } from "@web3-react/coinbase-wallet"
 import { useWeb3React } from "@web3-react/core"
 import { MetaMask } from "@web3-react/metamask"
 import { WalletConnect } from "@web3-react/walletconnect-v2"
-import useUser from "components/[guild]/hooks/useUser"
-import { deleteKeyPairFromIdb } from "components/_app/KeyPairProvider"
-import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import CopyableAddress from "components/common/CopyableAddress"
 import GuildAvatar from "components/common/GuildAvatar"
 import { Modal } from "components/common/Modal"
+import useUser from "components/[guild]/hooks/useUser"
+import { deleteKeyPairFromIdb } from "components/_app/KeyPairProvider"
+import { useWeb3ConnectionManager } from "components/_app/Web3ConnectionManager"
 import useResolveAddress from "hooks/resolving/useResolveAddress"
 import { SignOut } from "phosphor-react"
 import AccountConnections from "./components/AccountConnections"
@@ -64,7 +64,7 @@ const AccountModal = () => {
       window.localStorage.removeItem(key)
     })
 
-    deleteKeyPairFromIdb(id).catch(() => {})
+    deleteKeyPairFromIdb(id)?.catch(() => {})
   }
 
   const domain = useResolveAddress(account)


### PR DESCRIPTION
The keypair wasn't invalidated when the user switched to another wallet, so we sent an invalid public key to our API. I added the userId to the SWR key in this PR, so it'll be regenerated on wallet change.