### PR TITLE
V2 - Use migrated endpoints

### DIFF
--- a/cypress/e2e/1-discord/0-create-guild.spec.ts
+++ b/cypress/e2e/1-discord/0-create-guild.spec.ts
@@ -21,10 +21,13 @@ describe("create-discord-guild", () => {
   })
 
   it("can authenticate with Discord and create a guild", () => {
-    cy.intercept(`${Cypress.env("guildApiUrl")}/guild/listGateables`, {
-      statusCode: 200,
-      fixture: "testUserDiscordGateables.json",
-    }).as("fetchDiscordGateables")
+    cy.intercept(
+      `${Cypress.env("guildApiUrl")}/users/*/platforms/DISCORD/gateables`,
+      {
+        statusCode: 200,
+        fixture: "testUserDiscordGateables.json",
+      }
+    ).as("fetchDiscordGateables")
 
     cy.intercept(`${Cypress.env("guildApiUrl")}/user/connect`, {
       statusCode: 200,
@@ -63,7 +66,7 @@ describe("create-discord-guild", () => {
     cy.getByDataTest("DISCORD-select-button-connected").click()
     cy.wait("@fetchDiscordGateables")
 
-    cy.intercept(`${Cypress.env("guildApiUrl")}/platform/guild/DISCORD/*`).as(
+    cy.intercept(`${Cypress.env("guildApiUrl")}/platforms/DISCORD/guilds/*`).as(
       "useGuildByPlatformId"
     )
     cy.wait("@useGuildByPlatformId")

--- a/src/components/[guild]/CreatePoap/components/Distribution/components/SendPoapDiscordEmbed/SendPoapDiscordEmbed.tsx
+++ b/src/components/[guild]/CreatePoap/components/Distribution/components/SendPoapDiscordEmbed/SendPoapDiscordEmbed.tsx
@@ -37,7 +37,7 @@ import EmbedButton from "./components/EmbedButton"
 import EmbedDescription from "./components/EmbedDescription"
 import EmbedTitle from "./components/EmbedTitle"
 
-type PoapDiscordEmbedForm = {
+export type PoapDiscordEmbedForm = {
   poapId: number
   channelId: string
   title: string
@@ -85,18 +85,13 @@ const SendPoapDiscordEmbed = ({ poap, onSuccess }: Props): JSX.Element => {
 
   const triggerConfetti = useJsConfetti()
 
-  const { isLoading, isSigning, onSubmit, response, signLoadingText } = useSendJoin(
-    "POAP",
-    () => {
-      triggerConfetti()
-      onClose()
-      onSuccess()
-      // Mutating the guild data, so we get back the correct "activated" status for the POAPs
-      mutateGuild()
-    }
-  )
-
-  const loadingText = signLoadingText || "Sending"
+  const { isLoading, onSubmit, response } = useSendJoin("POAP", () => {
+    triggerConfetti()
+    onClose()
+    onSuccess()
+    // Mutating the guild data, so we get back the correct "activated" status for the POAPs
+    mutateGuild()
+  })
 
   return (
     <>
@@ -234,11 +229,10 @@ const SendPoapDiscordEmbed = ({ poap, onSuccess }: Props): JSX.Element => {
               <Button
                 colorScheme="green"
                 onClick={methods.handleSubmit(onSubmit)}
-                isLoading={isLoading || isSigning}
-                loadingText={loadingText}
+                isLoading={isLoading}
+                loadingText={"Sending"}
                 isDisabled={
                   isLoading ||
-                  isSigning ||
                   response ||
                   (poapEventDetails?.voiceChannelId &&
                     !poapEventDetails?.voiceEventEndedAt)

--- a/src/components/[guild]/CreatePoap/components/EditPoapRole/EditPoapRole.tsx
+++ b/src/components/[guild]/CreatePoap/components/EditPoapRole/EditPoapRole.tsx
@@ -21,7 +21,6 @@ import Description from "components/create-guild/Description"
 import DynamicDevTool from "components/create-guild/DynamicDevTool"
 import IconSelector from "components/create-guild/IconSelector"
 import Name from "components/create-guild/Name"
-import useToast from "hooks/useToast"
 import useWarnIfUnsavedChanges from "hooks/useWarnIfUnsavedChanges"
 import { Check, PencilSimple } from "phosphor-react"
 import { useRef } from "react"
@@ -44,7 +43,6 @@ type Props = {
  */
 const EditPoapRole = ({ poap, guildPoap }: Props): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const toast = useToast()
   const btnRef = useRef()
 
   const defaultValues = {
@@ -62,16 +60,11 @@ const EditPoapRole = ({ poap, guildPoap }: Props): JSX.Element => {
   })
 
   const onSuccess = () => {
-    toast({
-      status: "success",
-      title: "Role successfully updated!",
-    })
     onClose()
     methods.reset(undefined, { keepValues: true })
   }
 
-  const { onSubmit, isLoading, isSigning, signLoadingText } =
-    useUpdatePoapRequirements(guildPoap, { onSuccess })
+  const { onSubmit, isLoading } = useUpdatePoapRequirements(guildPoap, { onSuccess })
 
   const isDirty = !!Object.keys(methods.formState.dirtyFields).length
   useWarnIfUnsavedChanges(isDirty && !methods.formState.isSubmitted)
@@ -87,8 +80,6 @@ const EditPoapRole = ({ poap, guildPoap }: Props): JSX.Element => {
     onAlertClose()
     onClose()
   }
-
-  const loadingText = signLoadingText || "Saving data"
 
   return (
     <>
@@ -145,9 +136,9 @@ const EditPoapRole = ({ poap, guildPoap }: Props): JSX.Element => {
               Cancel
             </Button>
             <Button
-              isLoading={isLoading || isSigning}
+              isLoading={isLoading}
               colorScheme="green"
-              loadingText={loadingText}
+              loadingText={"Saving data"}
               onClick={methods.handleSubmit(onSubmit)}
               leftIcon={<Icon as={Check} />}
             >

--- a/src/components/[guild]/CreatePoap/hooks/useMintPoapButton.tsx
+++ b/src/components/[guild]/CreatePoap/hooks/useMintPoapButton.tsx
@@ -86,7 +86,7 @@ const MintModal = ({ isOpen, onClose, isLoading, response, error }) => {
               </Box>
             </HStack>
           ) : (
-            <ErrorAlert label={error} />
+            <ErrorAlert label={error?.error} />
           )}
         </ModalBody>
       </ModalContent>

--- a/src/components/[guild]/CreatePoap/hooks/usePoapLinks.ts
+++ b/src/components/[guild]/CreatePoap/hooks/usePoapLinks.ts
@@ -10,7 +10,7 @@ const usePoapLinks = (
   mutate: KeyedMutator<any>
 } => {
   const { account } = useWeb3React()
-  const { poaps } = useGuild()
+  const { poaps, id: guildId } = useGuild()
   const guildPoap = poaps?.find((p) => p.poapIdentifier === poapId)
 
   const {
@@ -18,7 +18,7 @@ const usePoapLinks = (
     isValidating: isPoapLinksLoading,
     mutate,
   } = useSWR(
-    poapId ? `/assets/poap/links/${poapId}` : null
+    poapId ? `/v2/guilds/${guildId}/poaps/${poapId}/links` : null
     // {
     //   refreshInterval:
     //     account && guildPoap?.expiryDate > Date.now() / 1000 ? 30000 : 0,

--- a/src/components/[guild]/CreatePoap/hooks/useUpdatePoapRequirements.ts
+++ b/src/components/[guild]/CreatePoap/hooks/useUpdatePoapRequirements.ts
@@ -1,9 +1,13 @@
+import {
+  countFailed,
+  getCorrelationId,
+} from "components/[guild]/EditGuild/hooks/useEditGuild"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useShowErrorToast from "hooks/useShowErrorToast"
-import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
-import { UseSubmitOptions } from "hooks/useSubmit/useSubmit"
-import { GuildPoap } from "types"
-import fetcher from "utils/fetcher"
+import useSubmit, { UseSubmitOptions } from "hooks/useSubmit/useSubmit"
+import useToast from "hooks/useToast"
+import { GuildPoap, Logic } from "types"
+import { useFetcherWithSign } from "utils/fetcher"
 import preprocessRequirements from "utils/preprocessRequirements"
 
 const useUpdatePoapRequirements = (
@@ -12,25 +16,132 @@ const useUpdatePoapRequirements = (
 ) => {
   const showErrorToast = useShowErrorToast()
 
-  const { mutateGuild } = useGuild()
+  const { mutateGuild, poaps, id: guildId } = useGuild()
+  const fetcherWithSign = useFetcherWithSign()
 
-  const updatePoapRequirements = async (signedValidation: SignedValdation) =>
-    fetcher(`/assets/poap/requirements/${guildPoap?.id}`, {
-      method: "PATCH",
-      ...signedValidation,
-    })
+  const updatePoapRequirements = async (body: {
+    logic: Logic
+    requirements: Omit<GuildPoap["poapRequirements"], "logic">
+  }) => {
+    const existingPoapRequirements = poaps?.flatMap((poap) => poap.poapRequirements)
 
-  const { onSubmit, ...rest } = useSubmitWithSign<GuildPoap>(
-    updatePoapRequirements,
-    {
-      onError: (error) => showErrorToast(error),
-      onSuccess: async () => {
-        mutateGuild()
+    const poapRequirementsToCreate =
+      body?.requirements?.filter((req) => !req.id) ?? []
+    const poapRequirementsToDelete =
+      existingPoapRequirements?.filter(
+        (existingReq) =>
+          !body?.requirements?.find((req) => req.id === existingReq.id)
+      ) ?? []
+    const poapRequirementsToUpdate =
+      body?.requirements?.filter((req) => !!req.id) ?? []
 
-        onSuccess?.()
+    const updates = Promise.all(
+      poapRequirementsToUpdate.map((req) =>
+        fetcherWithSign([
+          `/v2/guilds/${guildId}/poaps/${guildPoap?.id}/requirements/${req.id}`,
+          { method: "PUT", body: { ...req, logic: body?.logic, id: undefined } },
+        ]).catch((error) => error)
+      )
+    )
+
+    const creations = Promise.all(
+      poapRequirementsToCreate.map((req) =>
+        fetcherWithSign([
+          `/v2/guilds/${guildId}/poaps/${guildPoap?.id}/requirements`,
+          { method: "POST", body: { ...req, logic: body?.logic } },
+        ]).catch((error) => error)
+      )
+    )
+
+    const deletions = Promise.all(
+      poapRequirementsToDelete.map((req) =>
+        fetcherWithSign([
+          `/v2/guilds/${guildId}/poaps/${guildPoap?.id}/requirements/${req.id}`,
+          { method: "DELETE" },
+        ])
+          .then(() => req.id)
+          .catch((error) => error)
+      )
+    )
+
+    const [creationResults, updateResults, deletionResults] = await Promise.all([
+      creations,
+      updates,
+      deletions,
+    ])
+
+    return {
+      creations: {
+        success: creationResults.filter((res) => !res.error),
+        failedCount: countFailed(creationResults),
+        correlationId: getCorrelationId(creationResults),
       },
-    }
-  )
+      updates: {
+        success: updateResults.filter((res) => !res.error),
+        failedCount: countFailed(updateResults),
+        correlationId: getCorrelationId(updateResults),
+      },
+      deletions: {
+        success: deletionResults.filter((res) => !res.error),
+        failedCount: countFailed(deletionResults),
+        correlationId: getCorrelationId(deletionResults),
+      },
+    } as const
+  }
+
+  const toast = useToast()
+
+  const { onSubmit, ...rest } = useSubmit(updatePoapRequirements, {
+    onError: (error) => showErrorToast(error),
+    onSuccess: async ({ creations, deletions, updates }) => {
+      if (
+        creations.failedCount <= 0 &&
+        deletions.failedCount <= 0 &&
+        updates.failedCount <= 0
+      ) {
+        toast({
+          title: `Role successfully updated!`,
+          status: "success",
+        })
+      } else {
+        if (creations.failedCount > 0) {
+          showErrorToast({
+            error: "Failed to create some requirements",
+            correlationId: creations.correlationId,
+          })
+        }
+        if (updates.failedCount > 0) {
+          showErrorToast({
+            error: "Failed to update some requirements",
+            correlationId: updates.correlationId,
+          })
+        }
+        if (deletions.failedCount > 0) {
+          showErrorToast({
+            error: "Failed to delete some requirements",
+            correlationId: deletions.correlationId,
+          })
+        }
+      }
+
+      mutateGuild(
+        (prev) => ({
+          ...prev,
+          poaps: prev?.poaps?.map((prevPoap) =>
+            prevPoap?.id !== guildPoap?.id
+              ? prevPoap
+              : {
+                  ...prevPoap,
+                  poapRequirements: [...updates?.success, ...creations?.success],
+                }
+          ),
+        }),
+        { revalidate: false }
+      )
+
+      onSuccess?.()
+    },
+  })
 
   return {
     ...rest,

--- a/src/components/[guild]/CreatePoap/hooks/useUploadMintLinks.ts
+++ b/src/components/[guild]/CreatePoap/hooks/useUploadMintLinks.ts
@@ -15,7 +15,7 @@ type UploadMintLinksData = {
 const useUploadMintLinks = (poapId: number, { onSuccess }: UseSubmitOptions) => {
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
-  const { mutateGuild } = useGuild()
+  const { mutateGuild, id: guildId } = useGuild()
   const { mutate: mutatePoapLinks } = usePoapLinks(poapId)
 
   const [loadingText, setLoadingText] = useState<string>(null)
@@ -34,7 +34,7 @@ const useUploadMintLinks = (poapId: number, { onSuccess }: UseSubmitOptions) => 
 
     setLoadingText("Saving mint links")
 
-    return fetcher("/assets/poap/links", signedValidation)
+    return fetcher(`/v2/guilds/${guildId}/poaps/${poapId}/links`, signedValidation)
   }
 
   const { onSubmit, ...rest } = useSubmitWithSign<UploadMintLinksData>(

--- a/src/components/[guild]/EditGuild/components/TransferOwnership/TransferOwnership.tsx
+++ b/src/components/[guild]/EditGuild/components/TransferOwnership/TransferOwnership.tsx
@@ -66,7 +66,7 @@ const TransferOwnershipModal = ({ isOpen, onClose }) => {
     )
   }
 
-  const { onSubmit, isLoading, signLoadingText } = useTransferOwnership({
+  const { onSubmit, isLoading } = useTransferOwnership({
     onSuccess,
   })
 
@@ -102,7 +102,7 @@ const TransferOwnershipModal = ({ isOpen, onClose }) => {
               onClick={() => onSubmit({ to: newOwner })}
               colorScheme="red"
               isLoading={isLoading}
-              loadingText={signLoadingText}
+              loadingText={"Loading"}
               isDisabled={!isValidAddress}
             >
               Transfer ownership

--- a/src/components/[guild]/EditGuild/components/TransferOwnership/hooks/useTransferOwnership.ts
+++ b/src/components/[guild]/EditGuild/components/TransferOwnership/hooks/useTransferOwnership.ts
@@ -8,7 +8,7 @@ const useTransferOwnership = ({ onSuccess }) => {
   const fetcherWithSign = useFetcherWithSign()
   const submit = async ({ to }: { to: string }) =>
     fetcherWithSign([
-      `/v2/guilds/${id}/admins/${to}/ownership`,
+      `/v2/guilds/${id}/admins/${to}`,
       {
         method: "PUT",
         body: {

--- a/src/components/[guild]/EditGuild/components/TransferOwnership/hooks/useTransferOwnership.ts
+++ b/src/components/[guild]/EditGuild/components/TransferOwnership/hooks/useTransferOwnership.ts
@@ -1,19 +1,27 @@
 import useGuild from "components/[guild]/hooks/useGuild"
 import useShowErrorToast from "hooks/useShowErrorToast"
-import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
-import fetcher from "utils/fetcher"
+import useSubmit from "hooks/useSubmit"
+import { useFetcherWithSign } from "utils/fetcher"
 
 const useTransferOwnership = ({ onSuccess }) => {
   const { id } = useGuild()
-  const submit = async (signedValidation: SignedValdation) =>
-    fetcher(`/guild/${id}/ownership`, {
-      method: "PUT",
-      ...signedValidation,
-    })
+  const fetcherWithSign = useFetcherWithSign()
+  const submit = async ({ to }: { to: string }) =>
+    fetcherWithSign([
+      `/v2/guilds/${id}/admins/${to}/ownership`,
+      {
+        method: "PUT",
+        body: {
+          isOwner: true,
+        },
+        signOptions: {
+          forcePrompt: true,
+        },
+      },
+    ])
   const showErrorToast = useShowErrorToast()
 
-  return useSubmitWithSign<any>(submit, {
-    forcePrompt: true,
+  return useSubmit(submit, {
     onSuccess: (res) => {
       if (onSuccess) onSuccess(res)
     },

--- a/src/components/[guild]/EditGuild/components/UrlName.tsx
+++ b/src/components/[guild]/EditGuild/components/UrlName.tsx
@@ -9,11 +9,12 @@ import FormErrorMessage from "components/common/FormErrorMessage"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { useFormContext, useFormState } from "react-hook-form"
 import slugify from "slugify"
+import fetcher from "utils/fetcher"
 
 const checkUrlName = (urlName: string) =>
-  fetch(`${process.env.NEXT_PUBLIC_API}/guild/${urlName}`).then(
-    async (response) => response.ok && response.status !== 204
-  )
+  fetcher(`/v2/guilds/${urlName}`)
+    .then(() => true)
+    .catch(() => false)
 
 const UrlName = ({ maxWidth = "sm" }) => {
   const { errors } = useFormState()

--- a/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
+++ b/src/components/[guild]/EditGuild/hooks/useEditGuild.ts
@@ -13,10 +13,10 @@ type Props = {
   guildId?: string | number
 }
 
-const countFailed = (arr: Record<string, string>[]) =>
+export const countFailed = (arr: Record<string, string>[]) =>
   arr.filter((req) => !!req.error).length
 
-const getCorrelationId = (arr: Record<string, string>[]) =>
+export const getCorrelationId = (arr: Record<string, string>[]) =>
   arr.filter((req) => !!req.error)[0]?.correlationId
 
 const useEditGuild = ({ onSuccess, guildId }: Props = {}) => {

--- a/src/components/[guild]/JoinModal/hooks/useJoin.tsx
+++ b/src/components/[guild]/JoinModal/hooks/useJoin.tsx
@@ -1,9 +1,9 @@
-import { useMintGuildPinContext } from "components/[guild]/Requirements/components/GuildCheckout/MintGuildPinContext"
+import useMemberships from "components/explorer/hooks/useMemberships"
 import useAccess from "components/[guild]/hooks/useAccess"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useUser from "components/[guild]/hooks/useUser"
+import { useMintGuildPinContext } from "components/[guild]/Requirements/components/GuildCheckout/MintGuildPinContext"
 import { usePostHogContext } from "components/_app/PostHogProvider"
-import useMemberships from "components/explorer/hooks/useMemberships"
 import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
 import { useToastWithButton, useToastWithTweetButton } from "hooks/useToast"
 import { useRouter } from "next/router"
@@ -78,7 +78,7 @@ const useJoin = (onSuccess?: (response: Response) => void) => {
       setTimeout(() => {
         mutate(
           (prev) => [
-            ...prev,
+            ...(prev ?? []),
             {
               guildId: guild.id,
               isAdmin: false,

--- a/src/components/[guild]/Members/components/MembersExporter.tsx
+++ b/src/components/[guild]/Members/components/MembersExporter.tsx
@@ -31,7 +31,7 @@ const MembersExporter = (): JSX.Element => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { id, roles } = useGuild()
   const { data, isValidating } = useSWRWithOptionalAuth(
-    isOpen ? `/guild/${id}/members` : null
+    isOpen ? `/v2/guilds/${id}/members` : null
   )
 
   const downloadAnchorRef = useRef(null)

--- a/src/components/[guild]/Onboarding/components/SummonMembers/components/SendDiscordJoinButtonModal.tsx
+++ b/src/components/[guild]/Onboarding/components/SummonMembers/components/SendDiscordJoinButtonModal.tsx
@@ -27,15 +27,10 @@ const SendDiscordJoinButtonModal = ({
   onSuccess = undefined,
   serverId,
 }) => {
-  const { isLoading, isSigning, onSubmit, signLoadingText } = useSendJoin(
-    "JOIN",
-    () => {
-      onClose()
-      onSuccess?.()
-    }
-  )
-
-  const loadingText = signLoadingText || "Sending"
+  const { isLoading, onSubmit } = useSendJoin("JOIN", () => {
+    onClose()
+    onSuccess?.()
+  })
 
   const { description, name } = useGuild()
   const {
@@ -97,9 +92,9 @@ const SendDiscordJoinButtonModal = ({
           <Button
             colorScheme="green"
             onClick={methods.handleSubmit(onSubmit)}
-            isLoading={isLoading || isSigning}
-            loadingText={loadingText}
-            isDisabled={isLoading || isSigning}
+            isLoading={isLoading}
+            loadingText={"Sending"}
+            isDisabled={isLoading}
           >
             Send
           </Button>

--- a/src/components/[guild]/Onboarding/components/SummonMembers/hooks/useSendJoin.tsx
+++ b/src/components/[guild]/Onboarding/components/SummonMembers/hooks/useSendJoin.tsx
@@ -1,23 +1,32 @@
+import { PoapDiscordEmbedForm } from "components/[guild]/CreatePoap/components/Distribution/components/SendPoapDiscordEmbed/SendPoapDiscordEmbed"
 import useGuild from "components/[guild]/hooks/useGuild"
 import processConnectorError from "components/[guild]/JoinModal/utils/processConnectorError"
 import useShowErrorToast from "hooks/useShowErrorToast"
-import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
+import useSubmit from "hooks/useSubmit"
 import useToast from "hooks/useToast"
-import fetcher from "utils/fetcher"
+import { useFetcherWithSign } from "utils/fetcher"
+import { SummonMembersForm } from "../SummonMembers"
 
 const useSendJoin = (type: "JOIN" | "POAP", onSuccess?: () => void) => {
   const { mutateGuild } = useGuild()
 
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
+  const fetcerWithSign = useFetcherWithSign()
 
-  const sendJoin = (signedValidation: SignedValdation) =>
-    fetcher("/discord/sendButton", {
-      ...signedValidation,
-      method: "POST",
-    })
+  const sendJoin = ({
+    serverId,
+    ...body
+  }: SummonMembersForm | PoapDiscordEmbedForm) =>
+    fetcerWithSign([
+      `/v2/discord/servers/${serverId}/button`,
+      {
+        method: "POST",
+        body,
+      },
+    ])
 
-  const useSubmitResponse = useSubmitWithSign(sendJoin, {
+  const useSubmitResponse = useSubmit(sendJoin, {
     onError: (error) =>
       showErrorToast({
         error: processConnectorError(error.error) ?? error.error,

--- a/src/components/[guild]/Requirements/components/GuildCheckout/MintGuildPinContext.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/MintGuildPinContext.tsx
@@ -103,9 +103,7 @@ const MintGuildPinProviderComponent = ({
     isValidating: isImageValidating,
     error,
   } = useSWRImmutable(
-    shouldFetchImage
-      ? `/assets/guildPins/image?guildId=${id}&guildAction=${pinType}`
-      : null
+    shouldFetchImage ? `/v2/guilds/${id}/pin?guildAction=${pinType}` : null
   )
 
   const [mintedTokenId, setMintedTokenId] = useState<number>(null)

--- a/src/components/[guild]/Requirements/components/GuildCheckout/MintGuildPinContext.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/MintGuildPinContext.tsx
@@ -49,7 +49,7 @@ const MintGuildPinContext = createContext<
     isImageValidating: boolean
     isInvalidImage?: boolean
     isTooSmallImage?: boolean
-    error: string
+    error: any
     mintedTokenId?: number
     setMintedTokenId: Dispatch<SetStateAction<number>>
   } & GuildCheckoutContextType

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildPinImage.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/GuildPinImage.tsx
@@ -37,7 +37,9 @@ const GuildPinImage = (): JSX.Element => {
         <AlertIcon />
         <Stack top="1" position="relative" w="full">
           <AlertTitle>Couldn't generate Guild Pin</AlertTitle>
-          <AlertDescription wordBreak={"break-word"}>{error}</AlertDescription>
+          <AlertDescription wordBreak={"break-word"}>
+            {error?.error}
+          </AlertDescription>
         </Stack>
       </Alert>
     )

--- a/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/BuyButton.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/components/buttons/BuyButton.tsx
@@ -15,7 +15,7 @@ import { useGuildCheckoutContext } from "../GuildCheckoutContex"
 
 const BuyButton = (): JSX.Element => {
   const { captureEvent } = usePostHogContext()
-  const { urlName } = useGuild()
+  const { urlName, id: guildId } = useGuild()
   const toast = useToast()
 
   const { chainId } = useWeb3React()
@@ -45,7 +45,9 @@ const BuyButton = (): JSX.Element => {
   // temporary (in it's current form) until POAPs are real roles and there's a capacity attribute
   const handleSubmit = async () => {
     if (requirement?.poapId) {
-      const poapLinks = await fetcher(`/assets/poap/links/${requirement.poapId}`)
+      const poapLinks = await fetcher(
+        `/v2/guilds/${guildId}/poaps/${requirement.poapId}/links`
+      )
       if (poapLinks?.claimed === poapLinks?.total)
         return toast({
           status: "error",

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/useMintGuildPin.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/useMintGuildPin.tsx
@@ -64,7 +64,7 @@ const useMintGuildPin = () => {
       timestamp,
       cid,
       signature,
-    }: MintData = await fetcher("/assets/guildPins", {
+    }: MintData = await fetcher(`/v2/guilds/${id}/pin`, {
       body: {
         userAddress: account,
         guildId: id,

--- a/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePayFee.ts
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/hooks/usePayFee.ts
@@ -166,7 +166,7 @@ const usePayFee = () => {
       // temporary until POAPs are real roles
       if (requirement?.poapId)
         mutate(
-          `/assets/poap/checkUserPoapEligibility/${requirement.poapId}/${account}`
+          `/v2/guilds/:guildId/poaps/${requirement.poapId}/users/${account}/eligibility`
         )
       else mutate(`/guild/access/${id}/${account}`)
     },

--- a/src/components/[guild]/claim-poap/hooks/useClaimPoap.ts
+++ b/src/components/[guild]/claim-poap/hooks/useClaimPoap.ts
@@ -1,29 +1,25 @@
 import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
 import usePoapLinks from "components/[guild]/CreatePoap/hooks/usePoapLinks"
+import useGuild from "components/[guild]/hooks/useGuild"
 import useUser from "components/[guild]/hooks/useUser"
-import useSubmit from "hooks/useSubmit"
-import { UseSubmitOptions } from "hooks/useSubmit/useSubmit"
-import fetcher from "utils/fetcher"
-
-type ClaimPoapBody = {
-  poapId: number
-  userId: number
-}
-
-const fetchClaim = async (body: ClaimPoapBody) =>
-  fetcher("/assets/poap/claim", {
-    body,
-  })
+import { UseSubmitOptions, useSubmitWithSign } from "hooks/useSubmit/useSubmit"
+import { useFetcherWithSign } from "utils/fetcher"
 
 const useClaimPoap = (poapId: number, { onSuccess }: UseSubmitOptions = {}) => {
   const { id } = useUser()
+  const { id: guildId } = useGuild()
   // const showErrorToast = useShowErrorToast()
 
   const { mutate: mutatePoapLinks } = usePoapLinks(poapId)
   const triggerConfetti = useJsConfetti()
+  const fetcherWithSign = useFetcherWithSign()
 
-  return useSubmit<ClaimPoapBody, string>(
-    async () => fetchClaim({ poapId: poapId, userId: id }),
+  return useSubmitWithSign(
+    () =>
+      fetcherWithSign([
+        `/v2/guilds/${guildId}/poaps/${poapId}/links/users/${id}`,
+        { method: "POST" },
+      ]),
     {
       // onError: (error) => showErrorToast(error),
       onSuccess: () => {

--- a/src/components/[guild]/claim-poap/hooks/usePoapPayFee.ts
+++ b/src/components/[guild]/claim-poap/hooks/usePoapPayFee.ts
@@ -3,6 +3,7 @@ import { TransactionResponse } from "@ethersproject/providers"
 import { formatUnits, parseUnits } from "@ethersproject/units"
 import { useWeb3React } from "@web3-react/core"
 import usePoapVault from "components/[guild]/CreatePoap/hooks/usePoapVault"
+import useGuild from "components/[guild]/hooks/useGuild"
 import { Chains } from "connectors"
 import useContract from "hooks/useContract"
 import useFeeCollectorContract, {
@@ -26,6 +27,7 @@ const usePoapPayFee = (
   { onSuccess }: UseSubmitOptions = {}
 ) => {
   const { account } = useWeb3React()
+  const { id: guildId } = useGuild()
 
   const showErrorToast = useShowErrorToast()
   const toast = useToast()
@@ -43,7 +45,7 @@ const usePoapPayFee = (
   const erc20Contract = useContract(vaultData?.token, ERC20_ABI, true)
 
   const fetchPayFee = async () => {
-    await fetcher(`/api/poap/can-claim/${poap?.id}`).catch((e) => {
+    await fetcher(`/api/poap/can-claim/${poap?.id}/${guildId}`).catch((e) => {
       throw new Error(e?.error ?? "An unknown error occurred")
     })
 

--- a/src/components/[guild]/claim-poap/hooks/useUserPoapEligibility.ts
+++ b/src/components/[guild]/claim-poap/hooks/useUserPoapEligibility.ts
@@ -11,7 +11,7 @@ const useUserPoapEligibility = (poapIdentifier: number) => {
 
   const { data, isValidating, mutate } = useSWR(
     account && poapIdentifier
-      ? `/assets/poap/checkUserPoapEligibility/${poapIdentifier}/${account}`
+      ? `/v2/guilds/:guildId/poaps/${poapIdentifier}/users/${account}/eligibility`
       : null,
     {
       revalidateOnFocus: false,

--- a/src/components/[guild]/hooks/useAutoStatusUpdate.ts
+++ b/src/components/[guild]/hooks/useAutoStatusUpdate.ts
@@ -1,6 +1,6 @@
 import { useWeb3React } from "@web3-react/core"
-import { useKeyPair } from "components/_app/KeyPairProvider"
 import useMemberships from "components/explorer/hooks/useMemberships"
+import { useKeyPair } from "components/_app/KeyPairProvider"
 import { mutateOptionalAuthSWRKey } from "hooks/useSWRWithOptionalAuth"
 import { useEffect } from "react"
 import { useFetcherWithSign } from "utils/fetcher"
@@ -58,7 +58,7 @@ const useAutoStatusUpdate = () => {
       ]).then(() =>
         Promise.all([
           mutateOptionalAuthSWRKey(`/guild/access/${id}/${account}`),
-          mutateOptionalAuthSWRKey(`/user/membership/${account}`),
+          mutateOptionalAuthSWRKey(`/v2/users/${account}/memberships`),
         ])
       )
     }

--- a/src/components/create-guild/Requirements/components/RequirementEditableCard.tsx
+++ b/src/components/create-guild/Requirements/components/RequirementEditableCard.tsx
@@ -66,7 +66,10 @@ const RequirementEditableCard = ({
     onSubmit: onDeletePoapRequirement,
     isLoading: isPoapRequirementDeleteLoading,
     isSigning: isPoapRequirementDeleteSigning,
-  } = useDeletePoapRequirement(poapId, requirementId)
+  } = useDeletePoapRequirement(poapId, requirementId, () => {
+    removeRequirement(index)
+    onRequirementDeleteClose()
+  })
 
   const {
     isOpen: isAlertOpen,

--- a/src/components/create-guild/TelegramGroup/hooks/useIsTGBotIn.ts
+++ b/src/components/create-guild/TelegramGroup/hooks/useIsTGBotIn.ts
@@ -19,7 +19,7 @@ const useIsTGBotIn = (groupId: string, swrConfig?: SWRConfiguration) => {
 
   const { data, isValidating } = useSWR<IsTGBotInResponse>(
     shouldFetch
-      ? `/telegram/group/${groupId?.startsWith("-") ? groupId : `-${groupId}`}`
+      ? `/v2/telegram/groups/${groupId?.startsWith("-") ? groupId : `-${groupId}`}`
       : null,
     {
       fallbackData,

--- a/src/components/explorer/hooks/useMemberships.ts
+++ b/src/components/explorer/hooks/useMemberships.ts
@@ -14,7 +14,7 @@ const useMemberships = () => {
   const shouldFetch = !!account
 
   const { data, mutate, ...rest } = useSWRWithOptionalAuth<Memberships>(
-    shouldFetch ? `/user/membership/${account}` : null
+    shouldFetch ? `/v2/users/${account}/memberships` : null
   )
 
   return {

--- a/src/components/index/ExploreTrendingGuilds.tsx
+++ b/src/components/index/ExploreTrendingGuilds.tsx
@@ -8,7 +8,7 @@ import LandingButton from "./LandingButton"
 import LandingWideSection from "./LandingWideSection"
 
 const ExploreTrendingGuilds = (): JSX.Element => {
-  const { data: guilds, isValidating } = useSWR("/guild", {
+  const { data: guilds, isValidating } = useSWR("/v2/guilds", {
     refreshInterval: 0,
     revalidateIfStale: false,
     revalidateOnFocus: false,

--- a/src/hooks/useGateables.ts
+++ b/src/hooks/useGateables.ts
@@ -29,7 +29,7 @@ const useGateables = <K extends keyof Gateables>(
 ) => {
   const { keyPair } = useKeyPair()
 
-  const { platformUsers } = useUser()
+  const { platformUsers, id: userId } = useUser()
   const isConnected = !!platformUsers?.some(
     (platformUser) => platformUser.platformName === PlatformType[platformId]
   )
@@ -45,8 +45,8 @@ const useGateables = <K extends keyof Gateables>(
   const { data, isLoading, mutate, error } = useSWR<Gateables[K]>(
     shouldFetch
       ? [
-          "/guild/listGateables",
-          { method: "POST", body: { platformName: PlatformType[platformId] } },
+          `/v2/users/${userId}/platforms/${PlatformType[platformId]}/gateables`,
+          { method: "GET" },
         ]
       : null,
     (props) =>

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -55,7 +55,9 @@ const useServerData = (
   const shouldFetch = serverId?.length >= 0
   const { data, isValidating, error, mutate } = useSWR<ServerData>(
     shouldFetch
-      ? `/discord/server/${serverId}/${option?.memberCountDetails || false}`
+      ? `/v2/discord/servers/${serverId}?memberCountDetails=${
+          option?.memberCountDetails || false
+        }`
       : null,
     {
       fallbackData,

--- a/src/hooks/useTokenData.ts
+++ b/src/hooks/useTokenData.ts
@@ -27,7 +27,7 @@ const useTokenData = (chain: string, address: string, onFinish?: () => void) => 
   }, [tokensFromApi, address])
 
   const swrResponse = useSWRImmutable<Token>(
-    shouldFetch ? `/util/symbol/${address}/${chain}` : null,
+    shouldFetch ? `/v2/util/chains/${chain}/contracts/${address}/symbol` : null,
     {
       errorRetryInterval: 100,
       shouldRetryOnError: address?.toLowerCase() !== ENS_ADDRESS,

--- a/src/pages/api/linkpreview/[timestamp]/[guild].tsx
+++ b/src/pages/api/linkpreview/[timestamp]/[guild].tsx
@@ -33,7 +33,10 @@ const handler = async (req, _) => {
 
   if (!urlName) return new ImageResponse(<></>, { status: 404 })
 
-  const guild: Guild = await fetcher(`/guild/${urlName}`)
+  const [guild, guildRoles]: [Guild, Guild["roles"]] = await Promise.all([
+    fetcher(`/v2/guilds/${urlName}`),
+    fetcher(`/v2/guilds/${urlName}/roles`),
+  ])
 
   if (!guild?.id) return new ImageResponse(<></>, { status: 404 })
 
@@ -44,7 +47,7 @@ const handler = async (req, _) => {
       dystopianFont,
     ])
 
-    const roles = guild.roles?.map((role) => role.name)
+    const roles = guildRoles?.map((role) => role.name)
 
     const safeGuildDescription = guild.description?.replaceAll("\n", "")
 

--- a/src/pages/api/poap/can-claim/[poapId]/[guildId].ts
+++ b/src/pages/api/poap/can-claim/[poapId]/[guildId].ts
@@ -18,13 +18,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(405).json({ error: `Method ${req.method} is not allowed` })
   }
 
-  const { poapId } = req.query
+  const { poapId, guildId } = req.query
   const parsedPoapId = Number(poapId)
 
   if (isNaN(parsedPoapId))
     return res.status(400).json({ error: "Missing or invalid parameter(s)" })
 
-  const poapLinks = await fetcher(`/assets/poap/links/${poapId}`)
+  const poapLinks = await fetcher(`/v2/guilds/${guildId}/poaps/${poapId}/links`)
 
   if (!poapLinks) return res.status(404).json({ error: "Couldn't find POAP." })
 
@@ -34,7 +34,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       .json({ error: "There is no more claimable POAP left from this collection." })
 
   const poapData: PoapEventDetails = await fetcher(
-    `/assets/poap/eventDetails/${poapId}`
+    `/v2/guilds/${guildId}/poaps/${poapId}/event-details`
   )
 
   if (!poapData)

--- a/src/pages/api/poap/get-withdrawable-amount/[guildId]/[poapId].ts
+++ b/src/pages/api/poap/get-withdrawable-amount/[guildId]/[poapId].ts
@@ -24,7 +24,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const guildPoaps: Guild["poaps"] = await fetcher(
     `/v2/guilds/${guildId}/poaps`
-  ).catch((_) => ({}))
+  ).catch(() => [])
 
   const poap = guildPoaps?.find((p) => p.id.toString() === poapId)
 

--- a/src/pages/api/poap/get-withdrawable-amount/[guildId]/[poapId].ts
+++ b/src/pages/api/poap/get-withdrawable-amount/[guildId]/[poapId].ts
@@ -18,11 +18,15 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (!guildId || !poapId)
     return res.status(400).json({ error: "Missing parameters" })
 
-  const guild: Guild = await fetcher(`/guild/${guildId}`).catch((_) => ({}))
+  const guild: Guild = await fetcher(`/v2/guilds/${guildId}`).catch((_) => ({}))
 
   if (!guild.id) return res.status(404).json({ error: "Guild not found." })
 
-  const poap = guild.poaps?.find((p) => p.id.toString() === poapId)
+  const guildPoaps: Guild["poaps"] = await fetcher(
+    `/v2/guilds/${guildId}/poaps`
+  ).catch((_) => ({}))
+
+  const poap = guildPoaps?.find((p) => p.id.toString() === poapId)
 
   if (!poap) return res.status(404).json({ error: "POAP not found." })
 
@@ -38,7 +42,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         }/api/poap/get-vault/${poapContract.vaultId}/${poapContract.chainId}`
       ).then(async (data: GetVaultResponse) => {
         const tokenData = await fetcher(
-          `/util/symbol/${data.token}/${Chains[poapContract.chainId]}`
+          `/v2/util/chains/${Chains[poapContract.chainId]}/contracts/${
+            data.token
+          }/symbol`
         )
         const decimals =
           data.token === "0x0000000000000000000000000000000000000000"

--- a/src/platforms/Discord/DiscordCardMenu/components/DiscordCaptchaSwitch.tsx
+++ b/src/platforms/Discord/DiscordCardMenu/components/DiscordCaptchaSwitch.tsx
@@ -22,8 +22,8 @@ const DiscordCaptchaSwitch = ({ serverId }: Props): JSX.Element => {
   )
 
   const submit = (signedValidation: SignedValdation) =>
-    fetcher(`/guild/${id}/platform/${guildPlatform.id}`, {
-      method: "PATCH",
+    fetcher(`/v2/guilds/${id}/guild-platforms/${guildPlatform.id}`, {
+      method: "PUT",
       ...signedValidation,
     })
 

--- a/src/platforms/Discord/DiscordCardMenu/components/DiscordRewardSettings.tsx.tsx
+++ b/src/platforms/Discord/DiscordCardMenu/components/DiscordRewardSettings.tsx.tsx
@@ -29,8 +29,8 @@ const DiscordRewardSettings = ({ isOpen, onClose, serverId }) => {
   )
 
   const submit = (signedValidation: SignedValdation) =>
-    fetcher(`/guild/${id}/platform/${guildPlatform.id}`, {
-      method: "PATCH",
+    fetcher(`/v2/guilds/${id}/guild-platform/${guildPlatform.id}`, {
+      method: "PUT",
       ...signedValidation,
     })
 

--- a/src/platforms/Discord/DiscordCardMenu/components/DiscordRewardSettings.tsx.tsx
+++ b/src/platforms/Discord/DiscordCardMenu/components/DiscordRewardSettings.tsx.tsx
@@ -29,7 +29,7 @@ const DiscordRewardSettings = ({ isOpen, onClose, serverId }) => {
   )
 
   const submit = (signedValidation: SignedValdation) =>
-    fetcher(`/v2/guilds/${id}/guild-platform/${guildPlatform.id}`, {
+    fetcher(`/v2/guilds/${id}/guild-platforms/${guildPlatform.id}`, {
       method: "PUT",
       ...signedValidation,
     })

--- a/src/platforms/hooks/usePlatformUsageInfo.ts
+++ b/src/platforms/hooks/usePlatformUsageInfo.ts
@@ -15,7 +15,7 @@ const usePlatformUsageInfo = (
   const shouldFetch = platformId?.length > 0
   const { data: guildByPlatform, isValidating } = useSWRWithOptionalAuth<
     Partial<Guild>
-  >(shouldFetch ? `/platform/guild/${platform}/${platformId}` : null, {
+  >(shouldFetch ? `/v2/platforms/${platform}/guilds/${platformId}` : null, {
     shouldRetryOnError: false,
   })
 

--- a/src/requirements/Captcha/components/CompleteCaptcha.tsx
+++ b/src/requirements/Captcha/components/CompleteCaptcha.tsx
@@ -62,7 +62,9 @@ const CompleteCaptchaModal = ({ isOpen, onClose }) => {
     isValidating,
     error: getGateCallbackError,
   } = useSWRImmutable(
-    isOpen ? [`/util/getGateCallback/CAPTCHA`, { body: {} }] : null,
+    isOpen
+      ? [`/v2/util/gate-callbacks/session?requirement-type=CAPTCHA`, { body: {} }]
+      : null,
     fetcherWithSign
   )
 

--- a/src/requirements/Captcha/components/CompleteCaptcha.tsx
+++ b/src/requirements/Captcha/components/CompleteCaptcha.tsx
@@ -63,7 +63,7 @@ const CompleteCaptchaModal = ({ isOpen, onClose }) => {
     error: getGateCallbackError,
   } = useSWRImmutable(
     isOpen
-      ? [`/v2/util/gate-callbacks/session?requirement-type=CAPTCHA`, { body: {} }]
+      ? [`/v2/util/gate-callbacks/session?requirementType=CAPTCHA`, { body: {} }]
       : null,
     fetcherWithSign
   )

--- a/src/requirements/Galaxy/hooks/useGalaxyCampaigns.ts
+++ b/src/requirements/Galaxy/hooks/useGalaxyCampaigns.ts
@@ -14,7 +14,7 @@ type GalaxyCampaign = {
 
 export const useGalaxyCampaigns = (search = "") => {
   const { data, isLoading } = useSWRImmutable<GalaxyCampaign[]>(
-    search.length > 0 ? `/assets/galxe/campaign?search=${search}` : null
+    search.length > 0 ? `/v2/third-party/galxe/campaigns?search=${search}` : null
   )
 
   return { campaigns: data, isLoading }
@@ -24,7 +24,7 @@ export const useGalaxyCampaign = (
   id: string
 ): { campaign: GalaxyCampaign; isLoading: boolean } => {
   const { data, isLoading } = useSWRImmutable(
-    id?.length >= 10 ? `/assets/galxe/campaign/${id}` : null
+    id?.length >= 10 ? `/v2/third-party/galxe/campaigns/${id}` : null
   )
 
   return { campaign: data, isLoading }

--- a/src/requirements/Juicebox/hooks/useJuicebox.ts
+++ b/src/requirements/Juicebox/hooks/useJuicebox.ts
@@ -9,7 +9,7 @@ type JuiceboxProject = {
 
 export const useJuicebox = (search = "") => {
   const { data, isLoading } = useSWRImmutable<Array<JuiceboxProject>>(
-    search.length > 0 ? `/assets/juicebox/project?search=${search}` : null
+    search.length > 0 ? `/v2/third-party/juicebox/projects?search=${search}` : null
   )
 
   return { projects: data, isLoading }
@@ -17,7 +17,7 @@ export const useJuicebox = (search = "") => {
 
 export const useJuiceboxProject = (id: string) => {
   const { data, isLoading, error } = useSWRImmutable<JuiceboxProject>(
-    id ? `/assets/juicebox/project/${id}` : null
+    id ? `/v2/third-party/juicebox/projects/${id}` : null
   )
 
   return { project: data, isLoading, error }

--- a/src/requirements/Nft/NftRequirement.tsx
+++ b/src/requirements/Nft/NftRequirement.tsx
@@ -49,7 +49,7 @@ const NftRequirement = (props: RequirementProps) => {
   const { data: guildPinImageCID } = useSWRImmutable(
     isGuildPin
       ? // Fallback to "Our Guild" pin image
-        `/assets/guildPins/image?guildId=${guildIdAttribute ?? 1985}&guildAction=0`
+        `/v2/guilds/${guildIdAttribute ?? 1985}/pin?guildAction=0`
       : null
   )
   const { name: guildPinGuildName } = useGuild(guildIdAttribute ?? "")

--- a/src/requirements/Nft/hooks/useNftMetadata.ts
+++ b/src/requirements/Nft/hooks/useNftMetadata.ts
@@ -10,7 +10,7 @@ export type NftMetadata = {
   traits?: Record<string, Array<string>>
 }
 
-const baseUrl = `${process.env.NEXT_PUBLIC_API}/assets`
+const baseUrl = `/v2/third-party`
 
 const NOUNS_BACKGROUNDS = ["cool", "warm"]
 

--- a/src/requirements/Nft/hooks/useNftType.ts
+++ b/src/requirements/Nft/hooks/useNftType.ts
@@ -16,7 +16,7 @@ const useNftType = (
 
   const { data: nftType, isLoading } = useSWR(
     contractAddress && !isNounsContract
-      ? `/util/contractType/${contractAddress}/1/${chain}`
+      ? `/v2/util/chains/${chain}/contracts/${contractAddress}/tokens/1`
       : null,
     {
       revalidateOnFocus: false,

--- a/src/requirements/Nft/hooks/useNfts.ts
+++ b/src/requirements/Nft/hooks/useNfts.ts
@@ -4,7 +4,7 @@ import { NFT } from "types"
 
 const useNfts = (chain: Chain): { nfts: Array<NFT>; isLoading: boolean } => {
   const { isLoading, data } = useSWRImmutable(
-    chain === "ETHEREUM" ? `${process.env.NEXT_PUBLIC_API}/assets/nft/` : null
+    chain === "ETHEREUM" ? `/v2/third-party/nft/` : null
   )
 
   return { nfts: data, isLoading }

--- a/src/requirements/Poap/hooks/useGuildsPoaps.ts
+++ b/src/requirements/Poap/hooks/useGuildsPoaps.ts
@@ -3,7 +3,9 @@ import { Poap } from "types"
 import fetcher from "utils/fetcher"
 
 const fetchData = async (fancyIds: Array<string>) => {
-  const promises = fancyIds.map((fancyId) => fetcher(`/assets/poap/${fancyId}`))
+  const promises = fancyIds.map((fancyId) =>
+    fetcher(`/v2/third-party/poaps/${fancyId}`)
+  )
   return Promise.all(promises)
 }
 

--- a/src/requirements/Poap/hooks/usePoapById.ts
+++ b/src/requirements/Poap/hooks/usePoapById.ts
@@ -5,7 +5,7 @@ const usePoapById = (poapId: string): { poap: Poap; isPoapByIdLoading: boolean }
   const parsedPoapId = poapId?.replace("#", "")
 
   const { isValidating, data } = useSWRImmutable<Poap>(
-    poapId ? `/assets/poap/id/${parsedPoapId}` : null
+    poapId ? `/v2/third-party/poaps/${parsedPoapId}` : null
   )
 
   return { isPoapByIdLoading: isValidating, poap: data }

--- a/src/requirements/Poap/hooks/usePoaps.ts
+++ b/src/requirements/Poap/hooks/usePoaps.ts
@@ -6,7 +6,7 @@ export const usePoaps = (
   search = ""
 ): { poaps: Array<Poap>; isLoading: boolean } => {
   const { isLoading, data } = useSWRImmutable(
-    search.length > 0 ? `/assets/poap?search=${search}` : null
+    search.length > 0 ? `/v2/third-party/poaps?search=${search}` : null
   )
 
   return {
@@ -21,7 +21,7 @@ export const usePoap = (
   fancyId: string
 ): { poap: Poap; isLoading: boolean; mutatePoap: KeyedMutator<any>; error: any } => {
   const { isLoading, data, mutate, error } = useSWRImmutable<Poap>(
-    fancyId ? `/assets/poap/${fancyId}` : null
+    fancyId ? `/v2/third-party/poaps/${fancyId}` : null
   )
 
   return {

--- a/src/requirements/PoapPayment/PoapPaymentRequirementEditable.tsx
+++ b/src/requirements/PoapPayment/PoapPaymentRequirementEditable.tsx
@@ -38,10 +38,7 @@ const PoapPaymentRequirementEditable = ({
   const cancelRef = useRef()
   const removeRef = useRef()
 
-  const { onSubmit, isLoading, response } = useDeleteMonetization(
-    guildPoap?.id,
-    poapContractId
-  )
+  const { onSubmit, isLoading, response } = useDeleteMonetization(poapContractId)
 
   useEffect(() => {
     if (!response) return

--- a/src/requirements/PoapPayment/PoapPaymentRequirementEditable.tsx
+++ b/src/requirements/PoapPayment/PoapPaymentRequirementEditable.tsx
@@ -38,7 +38,10 @@ const PoapPaymentRequirementEditable = ({
   const cancelRef = useRef()
   const removeRef = useRef()
 
-  const { onSubmit, isLoading, response } = useDeleteMonetization(poapContractId)
+  const { onSubmit, isLoading, response } = useDeleteMonetization(
+    guildPoap?.id,
+    poapContractId
+  )
 
   useEffect(() => {
     if (!response) return

--- a/src/requirements/PoapPayment/hooks/useDeleteMonetization.ts
+++ b/src/requirements/PoapPayment/hooks/useDeleteMonetization.ts
@@ -4,19 +4,16 @@ import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
 import useToast from "hooks/useToast"
 import fetcher from "utils/fetcher"
 
-const useDeleteMonetization = (guildPoapId: number, poapContractId: number) => {
+const useDeleteMonetization = (poapContractId: number) => {
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
-  const { mutateGuild, id: guildId } = useGuild()
+  const { mutateGuild } = useGuild()
 
   const deleteMonetization = async (signedValidation: SignedValdation) =>
-    fetcher(
-      `/v2/guilds/${guildId}/poaps/${guildPoapId}/monetization-contracts/${poapContractId}`,
-      {
-        method: "DELETE",
-        ...signedValidation,
-      }
-    )
+    fetcher(`/assets/poap/monetize/${poapContractId}`, {
+      method: "DELETE",
+      ...signedValidation,
+    })
 
   return useSubmitWithSign<any>(deleteMonetization, {
     onError: (e) => showErrorToast(e),

--- a/src/requirements/PoapPayment/hooks/useDeleteMonetization.ts
+++ b/src/requirements/PoapPayment/hooks/useDeleteMonetization.ts
@@ -4,16 +4,19 @@ import { SignedValdation, useSubmitWithSign } from "hooks/useSubmit"
 import useToast from "hooks/useToast"
 import fetcher from "utils/fetcher"
 
-const useDeleteMonetization = (poapContractId: number) => {
+const useDeleteMonetization = (guildPoapId: number, poapContractId: number) => {
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
-  const { mutateGuild } = useGuild()
+  const { mutateGuild, id: guildId } = useGuild()
 
   const deleteMonetization = async (signedValidation: SignedValdation) =>
-    fetcher(`/assets/poap/monetize/${poapContractId}`, {
-      method: "DELETE",
-      ...signedValidation,
-    })
+    fetcher(
+      `/v2/guilds/${guildId}/poaps/${guildPoapId}/monetization-contracts/${poapContractId}`,
+      {
+        method: "DELETE",
+        ...signedValidation,
+      }
+    )
 
   return useSubmitWithSign<any>(deleteMonetization, {
     onError: (e) => showErrorToast(e),

--- a/src/requirements/PoapPayment/hooks/useMonetizePoap.ts
+++ b/src/requirements/PoapPayment/hooks/useMonetizePoap.ts
@@ -11,17 +11,14 @@ type MonetizePoapParams = {
   contract: string
 }
 
+const monetizePoap = (signedValidation: SignedValdation) =>
+  fetcher("/assets/poap/monetize", signedValidation)
+
 const useMonetizePoap = (callback?: () => void) => {
-  const { mutateGuild, id: guildId } = useGuild()
+  const { mutateGuild } = useGuild()
 
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
-
-  const monetizePoap = (signedValidation: SignedValdation) =>
-    fetcher(
-      `/v2/guilds/${guildId}/poaps/:poapId/monetization-contracts`,
-      signedValidation
-    )
 
   return useSubmitWithSign<any>(monetizePoap, {
     onError: (error) => showErrorToast(error?.message ?? error),

--- a/src/requirements/PoapPayment/hooks/useMonetizePoap.ts
+++ b/src/requirements/PoapPayment/hooks/useMonetizePoap.ts
@@ -11,14 +11,17 @@ type MonetizePoapParams = {
   contract: string
 }
 
-const monetizePoap = (signedValidation: SignedValdation) =>
-  fetcher("/assets/poap/monetize", signedValidation)
-
 const useMonetizePoap = (callback?: () => void) => {
-  const { mutateGuild } = useGuild()
+  const { mutateGuild, id: guildId } = useGuild()
 
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
+
+  const monetizePoap = (signedValidation: SignedValdation) =>
+    fetcher(
+      `/v2/guilds/${guildId}/poaps/:poapId/monetization-contracts`,
+      signedValidation
+    )
 
   return useSubmitWithSign<any>(monetizePoap, {
     onError: (error) => showErrorToast(error?.message ?? error),

--- a/src/requirements/PoapPayment/hooks/useRegisterVault.ts
+++ b/src/requirements/PoapPayment/hooks/useRegisterVault.ts
@@ -27,7 +27,9 @@ const useRegisterVault = (poapId, { onSuccess }: UseSubmitOptions) => {
     const tokenDataFromJSON = tokensFromJSON?.tokens?.find(
       (t) => t.address.toLowerCase() === token.toLowerCase()
     )
-    const tokenData = await fetcher(`/util/symbol/${token}/${Chains[chainId]}`)
+    const tokenData = await fetcher(
+      `/v2/util/chains/${Chains[chainId]}/contracts/${token}/symbol`
+    )
     const feeInWei = parseUnits(
       fee?.toString(),
       tokenDataFromJSON?.decimals ?? tokenData?.decimals ?? 18

--- a/src/requirements/PoapVoice/hooks/usePoapEventDetails.ts
+++ b/src/requirements/PoapVoice/hooks/usePoapEventDetails.ts
@@ -11,7 +11,7 @@ const usePoapEventDetails = (
   isPoapEventDetailsLoading: boolean
   mutatePoapEventDetails: KeyedMutator<any>
 } => {
-  const { guildPlatforms } = useGuild()
+  const { guildPlatforms, id: guildId } = useGuild()
   const { poapData } = useCreatePoapContext()
 
   const hasDiscordGuildPlatform = guildPlatforms?.some(
@@ -24,7 +24,7 @@ const usePoapEventDetails = (
 
   const { data, isValidating, mutate } = useSWRImmutable(
     shouldFetch
-      ? `/assets/poap/eventDetails/${poapData?.id ?? poapIdentifier}`
+      ? `/v2/guilds/${guildId}/poaps/${poapData?.id ?? poapIdentifier}/event-details`
       : null
   )
 

--- a/src/requirements/PolygonId/components/ConnectPolygonID.tsx
+++ b/src/requirements/PolygonId/components/ConnectPolygonID.tsx
@@ -95,7 +95,7 @@ const ConnectPolygonIDModal = ({
   } = useSWRImmutable(
     isOpen
       ? [
-          `/v2/util/gate-callbacks/session?requirement-type=${type}`,
+          `/v2/util/gate-callbacks/session?requirementType=${type}`,
           { body: { query: data.query } },
         ]
       : null,

--- a/src/requirements/PolygonId/components/ConnectPolygonID.tsx
+++ b/src/requirements/PolygonId/components/ConnectPolygonID.tsx
@@ -13,11 +13,11 @@ import {
   useBreakpointValue,
   useDisclosure,
 } from "@chakra-ui/react"
-import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
-import useAccess from "components/[guild]/hooks/useAccess"
 import Button from "components/common/Button"
 import ErrorAlert from "components/common/ErrorAlert"
 import { Modal } from "components/common/Modal"
+import useAccess from "components/[guild]/hooks/useAccess"
+import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
 import { ArrowsClockwise } from "phosphor-react"
 import { QRCodeSVG } from "qrcode.react"
 import { useEffect } from "react"
@@ -94,7 +94,10 @@ const ConnectPolygonIDModal = ({
     mutate,
   } = useSWRImmutable(
     isOpen
-      ? [`/util/getGateCallback/${type}`, { body: { query: data.query } }]
+      ? [
+          `/v2/util/gate-callbacks/session?requirement-type=${type}`,
+          { body: { query: data.query } },
+        ]
       : null,
     fetcherWithSign
   )

--- a/src/requirements/Snapshot/SnapshotRequirement.tsx
+++ b/src/requirements/Snapshot/SnapshotRequirement.tsx
@@ -28,7 +28,7 @@ const SnapshotRequirement = (props: RequirementProps): JSX.Element => {
 
   const { data: proposal } = useSWRImmutable<Proposal>(
     requirement.data.proposal
-      ? `/assets/snapshot/proposal/${requirement.data.proposal}`
+      ? `/v2/third-party/snapshot/proposals/${requirement.data.proposal}`
       : null
   )
 

--- a/src/requirements/Snapshot/components/SnapshotSpaceLink.tsx
+++ b/src/requirements/Snapshot/components/SnapshotSpaceLink.tsx
@@ -5,7 +5,7 @@ import { Space } from "./SpaceSelect"
 const SnapshotSpaceLink = ({ requirement }) => {
   const { data: space } = useSWRImmutable<Space>(
     requirement.data.space
-      ? `/assets/snapshot/space/${requirement.data.space}`
+      ? `/v2/third-party/snapshot/spaces/${requirement.data.space}`
       : null
   )
 

--- a/src/requirements/Snapshot/components/SpaceSelect.tsx
+++ b/src/requirements/Snapshot/components/SpaceSelect.tsx
@@ -40,12 +40,12 @@ const SpaceSelect = ({
   const [searchSpaceId, setSearchSpaceId] = useState("")
   const debouncedSearchSpaceId = useDebouncedState(searchSpaceId)
   const { data: spaces, isValidating: isSpacesLoading } = useSWRImmutable<Space[]>(
-    "/assets/snapshot/space"
+    "/v2/third-party/snapshot/spaces"
   )
   const { data: singleSpace, isValidating: isSingleSpaceLoading } =
     useSWRImmutable<Space>(
       debouncedSearchSpaceId
-        ? `/assets/snapshot/space/${debouncedSearchSpaceId}`
+        ? `/v2/third-party/snapshot/spaces/${debouncedSearchSpaceId}`
         : null
     )
 

--- a/src/requirements/Snapshot/components/Strategy/components/SingleStrategy.tsx
+++ b/src/requirements/Snapshot/components/Strategy/components/SingleStrategy.tsx
@@ -57,7 +57,7 @@ const SingleStrategy = ({ baseFieldPath, index }: Props): JSX.Element => {
 
   const { data: strategies, isValidating: isLoading } = useSWRImmutable<
     Record<string, SnapshotStrategy>
-  >("/assets/snapshot/strategy")
+  >("/v2/third-party/snapshot/strategies")
 
   const mappedStrategies = useMemo(
     () =>

--- a/src/requirements/Snapshot/hooks/useProposals.ts
+++ b/src/requirements/Snapshot/hooks/useProposals.ts
@@ -12,7 +12,7 @@ const useProposals = (
   spaceId?: string
 ): { proposals: Proposal[]; isProposalsLoading: boolean } => {
   const { data, isValidating } = useSWRImmutable<Proposal[]>(
-    `/assets/snapshot/proposal?search=${search ?? ""}`
+    `/v2/third-party/snapshot/proposals?search=${search ?? ""}`
   )
 
   const proposals = spaceId

--- a/src/requirements/Twitter/TwitterRequirement.tsx
+++ b/src/requirements/Twitter/TwitterRequirement.tsx
@@ -22,7 +22,7 @@ const TwitterRequirement = (props: RequirementProps) => {
 
   const { data: twitterAvatar } = useSWRImmutable(
     requirement.data.id && TWITTER_HANDLE_REGEX.test(requirement.data.id)
-      ? `/assets/twitter/avatar/${requirement.data.id}`
+      ? `/v2/third-party/twitter/users/${requirement.data.id}/avatar`
       : null
   )
 

--- a/src/requirements/Twitter/components/TwitterUserInput.tsx
+++ b/src/requirements/Twitter/components/TwitterUserInput.tsx
@@ -30,7 +30,7 @@ const TwitterUserInput = ({ baseFieldPath }: RequirementFormProps) => {
 
   const { data: twitterAvatar, isValidating } = useSWRImmutable(
     debouncedUsername && TWITTER_HANDLE_REGEX.test(debouncedUsername)
-      ? `/assets/twitter/avatar/${debouncedUsername}`
+      ? `/v2/third-party/twitter/users/${debouncedUsername}/avatar`
       : null
   )
 


### PR DESCRIPTION
Linear issue: https://linear.app/guildxyz/issue/GUILD-1116/fe-n-uj-endpointokat-hasznalni

Most of the changes only touch the URLs and methods of the requests. I think the only big change is in `useUpdatePoapRequirements`, which needed to be reimplemented to send out multiple requests, as it has been done for regular roles

### Deployment steps
- [x] https://github.com/agoraxyz/guild-backend/pull/1015 needs to be merged before this one