### PR TITLE
Use proper creation endpoints

### DIFF
--- a/cypress/e2e/0-platformless/0-create-guild.spec.ts
+++ b/cypress/e2e/0-platformless/0-create-guild.spec.ts
@@ -64,7 +64,7 @@ describe("with wallet", () => {
     cy.get("input[name='socialLinks.TWITTER']").clear().type("twitter.com/guildxyz")
     cy.getByDataTest("create-guild-button").should("be.enabled")
 
-    cy.intercept("POST", `${Cypress.env("guildApiUrl")}/guilds/with-roles`).as(
+    cy.intercept("POST", `${Cypress.env("guildApiUrl")}/guilds`).as(
       "createGuildRequest"
     )
 

--- a/cypress/e2e/0-platformless/1-manage-roles.spec.ts
+++ b/cypress/e2e/0-platformless/1-manage-roles.spec.ts
@@ -40,9 +40,7 @@ describe("roles", () => {
 
     cy.intercept(
       "POST",
-      `${Cypress.env("guildApiUrl")}/guilds/${
-        CONTEXT.guild.id
-      }/roles/with-requirements-and-rewards`
+      `${Cypress.env("guildApiUrl")}/guilds/${CONTEXT.guild.id}/roles`
     ).as("createRoleApiCall")
 
     cy.getByDataTest("add-role-button").click()

--- a/src/components/create-guild/hooks/useCreateGuild.tsx
+++ b/src/components/create-guild/hooks/useCreateGuild.tsx
@@ -20,7 +20,7 @@ const useCreateGuild = () => {
   const fetcherWithSign = useFetcherWithSign()
 
   const fetchData = async (signedValidation: SignedValdation): Promise<Guild> =>
-    fetcher("/v2/guilds/with-roles", signedValidation)
+    fetcher("/v2/guilds", signedValidation)
 
   const useSubmitResponse = useSubmitWithSign<Guild>(fetchData, {
     onError: (error_) =>

--- a/src/components/create-guild/hooks/useCreateRole.tsx
+++ b/src/components/create-guild/hooks/useCreateRole.tsx
@@ -33,7 +33,7 @@ const useCreateRole = (onSuccess?: () => void) => {
   const { id, urlName, mutateGuild } = useGuild()
 
   const fetchData = async (signedValidation: SignedValdation): Promise<Role> =>
-    fetcher(`/v2/guilds/${id}/roles/with-requirements-and-rewards`, signedValidation)
+    fetcher(`/v2/guilds/${id}/roles`, signedValidation)
 
   const useSubmitResponse = useSubmitWithSign<Role>(fetchData, {
     onError: (error_) =>


### PR DESCRIPTION
This PR uses the guild and role creation endpoints without `/with-roles` and `/with-requirements-and-rewards` suffixes

### Deployment steps

- [ ] https://github.com/agoraxyz/guild-backend/pull/1026 needs to be live before we merge this PR