### PR TITLE
feat(ContractStateForm): define values manually

### DIFF
--- a/src/requirements/ContractState/ContractStateForm.tsx
+++ b/src/requirements/ContractState/ContractStateForm.tsx
@@ -1,30 +1,44 @@
 import {
   Divider,
   FormControl,
+  FormHelperText,
   FormLabel,
   HStack,
+  IconButton,
   Input,
+  InputGroup,
+  InputLeftAddon,
+  InputRightElement,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
   Stack,
+  Text,
   Tooltip,
 } from "@chakra-ui/react"
+import Button from "components/common/Button"
 import ControlledSelect from "components/common/ControlledSelect"
 import FormErrorMessage from "components/common/FormErrorMessage"
-import { Chain, RPC } from "connectors"
-import { Info } from "phosphor-react"
+import { Info, Plus, X } from "phosphor-react"
 import { useEffect, useMemo } from "react"
-import { Controller, useFormContext, useWatch } from "react-hook-form"
+import { Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
 import parseFromObject from "utils/parseFromObject"
 import ChainPicker from "../common/ChainPicker"
 import useAbi from "./hooks/useAbi"
 
 const ADDRESS_REGEX = /^0x[A-F0-9]{40}$/i
+const USER_ADDRESS_HELPER_TEXT =
+  "'USER_ADDRESS' autofills the actual user's address when checking access"
 
 const getParamTypes = (params) => params.map((param) => param.type).join(",")
 
 const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
   const {
     control,
+    register,
     setValue,
     clearErrors,
     formState: { errors, touchedFields },
@@ -35,12 +49,17 @@ const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
   const method = useWatch({ name: `${baseFieldPath}.data.id` })
   const resultIndex = useWatch({ name: `${baseFieldPath}.data.resultIndex` })
 
-  // Reset form on chain change
-  const resetForm = () => {
-    setValue(`${baseFieldPath}.address`, "")
+  const resetFormWithoutAddress = () => {
     setValue(`${baseFieldPath}.data.id`, "")
     setValue(`${baseFieldPath}.data.resultIndex`, undefined)
     setValue(`${baseFieldPath}.data.expected`, "")
+    setValue(`${baseFieldPath}.data.params`, [])
+  }
+
+  const resetForm = () => {
+    setValue(`${baseFieldPath}.address`, "")
+    resetFormWithoutAddress()
+
     clearErrors([`${baseFieldPath}.address`])
   }
 
@@ -64,11 +83,7 @@ const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
   )
 
   const methodData = useMemo(
-    () =>
-      abi &&
-      method &&
-      (abi.find((m) => m.name === method.split("(")[0]) ||
-        setValue(`${baseFieldPath}.data.id`, null)),
+    () => abi && method && abi.find((m) => m.name === method.split("(")[0]),
     [abi, method]
   )
 
@@ -102,13 +117,19 @@ const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
     ]
   }, [outputType])
 
+  const shouldRenderSimpleInputs = Array.isArray(abi) && !abi.length
+  const {
+    fields: paramsFields,
+    append: appendParam,
+    remove: removeParam,
+  } = useFieldArray({
+    name: `${baseFieldPath}.data.params`,
+  })
+
   return (
     <Stack spacing={4} alignItems="start">
       <ChainPicker
         controlName={`${baseFieldPath}.chain` as const}
-        supportedChains={Object.entries(RPC)
-          .filter(([, rpcData]) => !!rpcData.apiUrl)
-          .map(([chainIdentifier]) => chainIdentifier as Chain)}
         onChange={resetForm}
       />
 
@@ -134,7 +155,10 @@ const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
               ref={ref}
               placeholder="Paste address"
               value={value ?? ""}
-              onChange={onChange}
+              onChange={(e) => {
+                onChange(e)
+                resetFormWithoutAddress()
+              }}
               onBlur={onBlur}
             />
           )}
@@ -145,83 +169,178 @@ const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
             parseFromObject(errors, baseFieldPath)?.address?.message}
         </FormErrorMessage>
       </FormControl>
-      <FormControl isRequired isDisabled={!abi}>
+
+      <FormControl isRequired>
         <FormLabel>Method:</FormLabel>
 
-        <ControlledSelect
-          name={`${baseFieldPath}.data.id`}
-          rules={{ required: "This field is required." }}
-          isClearable
-          isLoading={isAbiValidating}
-          options={methodOptions}
-          placeholder="Choose method"
-        />
+        {shouldRenderSimpleInputs ? (
+          <>
+            <Input {...register(`${baseFieldPath}.data.id`)} />
+            <FormHelperText>Example: balanceOf(address)(uint256)</FormHelperText>
+          </>
+        ) : (
+          <ControlledSelect
+            name={`${baseFieldPath}.data.id`}
+            rules={{ required: "This field is required." }}
+            isClearable
+            isLoading={isAbiValidating}
+            options={methodOptions}
+            placeholder="Choose method"
+          />
+        )}
 
         <FormErrorMessage>
           {parseFromObject(errors, baseFieldPath)?.data?.id}
         </FormErrorMessage>
       </FormControl>
-      {methodData?.inputs?.map((input, i) => (
-        <FormControl
-          key={`${input.name}${i}`}
-          isRequired
-          isInvalid={
-            error || parseFromObject(errors, baseFieldPath)?.data?.params?.[i]
-          }
-        >
-          <HStack mb="2" spacing="0">
-            <FormLabel mb="0">{`${i + 1}. input param: ${input.name}`}</FormLabel>
-            {input.type === "address" && (
-              <Tooltip
-                label={
-                  "'USER_ADDRESS' autofills the actual user's address when checking access"
-                }
-              >
-                <Info />
-              </Tooltip>
-            )}
-          </HStack>
 
-          <Controller
-            name={`${baseFieldPath}.data.params.${i}` as const}
-            control={control}
-            shouldUnregister
-            // rules={{ required: "This field is required." }}
-            defaultValue={input.type === "address" ? "USER_ADDRESS" : ""}
-            render={({ field: { onChange, onBlur, value, ref } }) => (
-              <Input
-                ref={ref}
-                placeholder={`${input.type}`}
-                value={value ?? ""}
-                onChange={onChange}
-                onBlur={onBlur}
+      {shouldRenderSimpleInputs ? (
+        <>
+          <Stack spacing={1}>
+            <Text fontWeight="medium">Params:</Text>
+            <Text fontSize="sm" colorScheme="gray">
+              {`Tip: ${USER_ADDRESS_HELPER_TEXT}`}
+            </Text>
+          </Stack>
+
+          {paramsFields.map((field, i) => (
+            <FormControl key={field.id}>
+              <FormLabel>{`${i + 1}. param:`}</FormLabel>
+              <InputGroup>
+                <Input {...register(`${baseFieldPath}.data.params.${i}.value`)} />
+                <InputRightElement>
+                  <IconButton
+                    aria-label="Remove parameter"
+                    icon={<X />}
+                    size="xs"
+                    variant="ghost"
+                    rounded="full"
+                    onClick={() => removeParam(i)}
+                  />
+                </InputRightElement>
+              </InputGroup>
+            </FormControl>
+          ))}
+
+          <Button
+            w="full"
+            leftIcon={<Plus />}
+            onClick={() => appendParam({ value: "" })}
+          >
+            Add parameter
+          </Button>
+        </>
+      ) : (
+        <>
+          {methodData?.inputs?.map((input, i) => (
+            <FormControl
+              key={`${input.name}${i}`}
+              isRequired
+              isInvalid={
+                error || !!parseFromObject(errors, baseFieldPath)?.data?.params?.[i]
+              }
+            >
+              <HStack mb="2" spacing="0">
+                <FormLabel mb="0">{`${i + 1}. input param: ${
+                  input.name
+                }`}</FormLabel>
+                {input.type === "address" && (
+                  <Tooltip label={USER_ADDRESS_HELPER_TEXT}>
+                    <Info />
+                  </Tooltip>
+                )}
+              </HStack>
+
+              <Controller
+                name={`${baseFieldPath}.data.params.${i}.value` as const}
+                control={control}
+                shouldUnregister
+                defaultValue={input.type === "address" ? "USER_ADDRESS" : ""}
+                render={({ field: { onChange, onBlur, value, ref } }) => (
+                  <Input
+                    ref={ref}
+                    placeholder={`${input.type}`}
+                    value={value ?? ""}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                  />
+                )}
               />
-            )}
-          />
 
-          <FormErrorMessage>
-            {parseFromObject(errors, baseFieldPath)?.data?.params?.[i]}
-          </FormErrorMessage>
-        </FormControl>
-      ))}
+              <FormErrorMessage>
+                {parseFromObject(errors, baseFieldPath)?.data?.params?.[i]?.message}
+              </FormErrorMessage>
+            </FormControl>
+          ))}
+        </>
+      )}
 
       <Divider />
 
-      <FormControl isRequired isDisabled={!method}>
+      <FormControl
+        isRequired
+        isInvalid={!!parseFromObject(errors, baseFieldPath)?.data?.resultIndex}
+        isDisabled={!method}
+      >
         <FormLabel>Expected output:</FormLabel>
 
-        {outputOptions?.length > 1 && (
-          <ControlledSelect
+        {shouldRenderSimpleInputs ? (
+          <Controller
             name={`${baseFieldPath}.data.resultIndex`}
+            control={control}
             defaultValue={0}
-            rules={{ required: "This field is required." }}
-            isLoading={isAbiValidating}
-            options={outputOptions}
-            placeholder="Choose output param"
-            chakraStyles={{ container: { mb: 2 } } as any}
+            rules={{
+              required: "This field is required.",
+              min: {
+                value: 0,
+                message: "Must be positive",
+              },
+            }}
+            render={({ field: { onChange, onBlur, value, ref } }) => (
+              <InputGroup>
+                <InputLeftAddon>Output param index</InputLeftAddon>
+                <NumberInput
+                  ref={ref}
+                  value={value}
+                  defaultValue={0}
+                  onChange={(_, valueAsNumber) =>
+                    onChange(!isNaN(valueAsNumber) ? valueAsNumber : "")
+                  }
+                  onBlur={onBlur}
+                  min={0}
+                >
+                  <NumberInputField borderLeftRadius={0} />
+                  <NumberInputStepper>
+                    <NumberIncrementStepper />
+                    <NumberDecrementStepper />
+                  </NumberInputStepper>
+                </NumberInput>
+              </InputGroup>
+            )}
           />
+        ) : (
+          outputOptions?.length > 1 && (
+            <ControlledSelect
+              name={`${baseFieldPath}.data.resultIndex`}
+              defaultValue={0}
+              rules={{ required: "This field is required." }}
+              isLoading={isAbiValidating}
+              options={outputOptions}
+              placeholder="Choose output param"
+              chakraStyles={{ container: { mb: 2 } } as any}
+            />
+          )
         )}
 
+        <FormErrorMessage>
+          {parseFromObject(errors, baseFieldPath)?.data?.resultIndex?.message}
+        </FormErrorMessage>
+      </FormControl>
+
+      <FormControl
+        isDisabled={!method}
+        isInvalid={!!parseFromObject(errors, baseFieldPath)?.data?.expected}
+      >
         <HStack>
           <ControlledSelect
             name={`${baseFieldPath}.data.resultMatch`}
@@ -245,8 +364,9 @@ const ContractStateForm = ({ baseFieldPath }: RequirementFormProps) => {
             )}
           />
         </HStack>
+
         <FormErrorMessage>
-          {parseFromObject(errors, baseFieldPath)?.data?.expected}
+          {parseFromObject(errors, baseFieldPath)?.data?.expected?.message}
         </FormErrorMessage>
       </FormControl>
     </Stack>

--- a/src/requirements/ContractState/ContractStateRequirement.tsx
+++ b/src/requirements/ContractState/ContractStateRequirement.tsx
@@ -65,10 +65,10 @@ const ContractStateRequirement = (props: RequirementProps) => {
                     borderBottomRadius="xl"
                   >
                     <Tbody fontWeight="normal" fontSize="xs">
-                      {(requirement.data.params as string[])?.map((param, i) => (
+                      {requirement.data.params?.map((param, i) => (
                         <Tr key={i}>
                           <Td>{`${i + 1}. input param`}</Td>
-                          <Td>{param}</Td>
+                          <Td>{param.value}</Td>
                         </Tr>
                       ))}
                       <Tr fontWeight={"semibold"}>

--- a/src/utils/handleSubmitDirty.ts
+++ b/src/utils/handleSubmitDirty.ts
@@ -22,6 +22,7 @@ const KEYS_TO_KEEP = [
   "admins",
   "contacts",
   "featureFlags",
+  "type",
 ]
 
 /**

--- a/src/utils/mapRequirements.ts
+++ b/src/utils/mapRequirements.ts
@@ -23,6 +23,19 @@ const mapRequirements = (requirements?: Array<Requirement>) =>
         ? "CUSTOM_ID"
         : "AMOUNT"
 
+    if (
+      newRequirement.type === "CONTRACT" &&
+      Array.isArray(requirement.data.params)
+    ) {
+      newRequirement.data.params = requirement.data.params.map((param) =>
+        typeof param === "string"
+          ? {
+              value: param,
+            }
+          : param
+      )
+    }
+
     // Removind id, roleId, symbol, name, since we don't need those in the form
     // delete newRequirement.id
     delete newRequirement.roleId

--- a/src/utils/preprocessRequirements.ts
+++ b/src/utils/preprocessRequirements.ts
@@ -4,7 +4,6 @@ import { Requirement, RequirementType } from "types"
 const preprocessRequirements = (
   requirements: Array<Partial<Requirement>>
 ): Requirement[] => {
-  console.log("preprocessRequirements")
   if (!requirements || !Array.isArray(requirements)) return undefined
 
   const freeRequirement = requirements.find(
@@ -121,7 +120,6 @@ const preprocessRequirements = (
         )
           processedRequirement.data.addresses = []
 
-        console.log("preprocessRequirements:type", requirement.type)
         if (
           /**
            * TODO: we couldn't use the type field here, because `handleSubmitDirty`
@@ -131,7 +129,6 @@ const preprocessRequirements = (
           // requirement.type === "CONTRACT" &&
           Array.isArray(requirement.data.params)
         ) {
-          console.log("preprocessing contract state params", requirement.data.params)
           processedRequirement.data.params = requirement.data.params.map(
             (param) => param.value
           )

--- a/src/utils/preprocessRequirements.ts
+++ b/src/utils/preprocessRequirements.ts
@@ -4,6 +4,7 @@ import { Requirement, RequirementType } from "types"
 const preprocessRequirements = (
   requirements: Array<Partial<Requirement>>
 ): Requirement[] => {
+  console.log("preprocessRequirements")
   if (!requirements || !Array.isArray(requirements)) return undefined
 
   const freeRequirement = requirements.find(
@@ -119,6 +120,22 @@ const preprocessRequirements = (
           !requirement.data.hideAllowlist
         )
           processedRequirement.data.addresses = []
+
+        console.log("preprocessRequirements:type", requirement.type)
+        if (
+          /**
+           * TODO: we couldn't use the type field here, because `handleSubmitDirty`
+           * removes it in most cases, but we should fix this issue and uncomment
+           * this line
+           */
+          // requirement.type === "CONTRACT" &&
+          Array.isArray(requirement.data.params)
+        ) {
+          console.log("preprocessing contract state params", requirement.data.params)
+          processedRequirement.data.params = requirement.data.params.map(
+            (param) => param.value
+          )
+        }
 
         // needed for POAP requirements, temporary
         delete (processedRequirement as any).requirementId

--- a/src/utils/preprocessRequirements.ts
+++ b/src/utils/preprocessRequirements.ts
@@ -121,13 +121,8 @@ const preprocessRequirements = (
           processedRequirement.data.addresses = []
 
         if (
-          /**
-           * TODO: we couldn't use the type field here, because `handleSubmitDirty`
-           * removes it in most cases, but we should fix this issue and uncomment
-           * this line
-           */
-          // requirement.type === "CONTRACT" &&
-          Array.isArray(requirement.data.params)
+          requirement.type === "CONTRACT" &&
+          Array.isArray(requirement.data?.params)
         ) {
           processedRequirement.data.params = requirement.data.params.map(
             (param) => param.value


### PR DESCRIPTION
This PR adds support for the `CONTRACT` requirement type on all supported networks by allowing the users to fill out the form manually instead of selecting values from select inputs. The original functionality still works if we can fetch the contract ABI from the API.