### PR TITLE
feat(SetVisibility): add PulseMarkers

### DIFF
--- a/src/components/[guild]/SetVisibility.tsx
+++ b/src/components/[guild]/SetVisibility.tsx
@@ -16,8 +16,10 @@ import {
   useDisclosure,
 } from "@chakra-ui/react"
 import Button from "components/common/Button"
+import PulseMarker from "components/common/PulseMarker"
 import RadioSelect from "components/common/RadioSelect"
 import { Option } from "components/common/RadioSelect/RadioSelect"
+import useLocalStorage from "hooks/useLocalStorage"
 import { Detective, Eye, EyeSlash, IconProps } from "phosphor-react"
 import { ForwardRefExoticComponent, RefAttributes, useRef } from "react"
 import { useController, useFormContext, useWatch } from "react-hook-form"
@@ -128,6 +130,13 @@ const SetVisibility = ({
     name: `${parentField}.visibility`,
   })
 
+  const [hasSeenRoleVisibility, setHasSeenRoleVisibility] = useLocalStorage(
+    "hasSeenRoleVisibility",
+    false
+  )
+  const [hasSeenRequirementVisibility, setHasSeenRequirementVisibility] =
+    useLocalStorage("hasSeenRequirementVisibility", false)
+
   if (!currentVisibility) {
     return null
   }
@@ -137,31 +146,44 @@ const SetVisibility = ({
   return (
     <>
       {entityType === "role" ? (
-        <Button
-          ml={3}
-          size="xs"
-          leftIcon={<Icon />}
-          onClick={onOpen}
-          ref={buttonRef}
-          {...buttonProps}
-        >
-          {visibilityData[currentVisibility].title}
-        </Button>
+        <PulseMarker placement="top" hidden={hasSeenRoleVisibility}>
+          <Button
+            ml={3}
+            size="xs"
+            leftIcon={<Icon />}
+            onClick={() => {
+              setHasSeenRoleVisibility(true)
+              onOpen()
+            }}
+            ref={buttonRef}
+            {...buttonProps}
+          >
+            {visibilityData[currentVisibility].title}
+          </Button>
+        </PulseMarker>
       ) : (
         <Tooltip
           label={`${visibilityData[currentVisibility].title}: ${visibilityData[currentVisibility].description}`}
+          placement="top"
+          hasArrow
+          shouldWrapChildren
         >
-          <IconButton
-            size={"sm"}
-            variant="ghost"
-            bg="unset !important"
-            icon={<Icon />}
-            aria-label="Set visibility"
-            onClick={onOpen}
-            ref={buttonRef}
-            ml={1}
-            color="gray"
-          />
+          <PulseMarker placement="top" hidden={hasSeenRequirementVisibility}>
+            <IconButton
+              size={"sm"}
+              variant="ghost"
+              bg="unset !important"
+              icon={<Icon />}
+              aria-label="Set visibility"
+              onClick={() => {
+                setHasSeenRequirementVisibility(true)
+                onOpen()
+              }}
+              ref={buttonRef}
+              ml={1}
+              color="gray"
+            />
+          </PulseMarker>
         </Tooltip>
       )}
 


### PR DESCRIPTION
I think we could wrap the `SetVisibility` buttons in `PulseMarker`s until the user doesn't click on them. It's a small change, but maybe this way our users would notice that we released this new feature for everyone.