### PR TITLE
feat(AddRewardButton): send detailed rolePlatform data

### DIFF
--- a/src/components/[guild]/AddRewardButton/AddRewardButton.tsx
+++ b/src/components/[guild]/AddRewardButton/AddRewardButton.tsx
@@ -91,7 +91,7 @@ const AddRewardButton = (): JSX.Element => {
           ?.filter((roleId) => !!roleId)
           .map((roleId) => ({
             // We'll be able to send additional params here, like capacity & time
-            platformRoleId: roleId,
+            roleId: +roleId,
             visibility: roles.find((role) => role.id === +roleId).visibility,
           })),
       })

--- a/src/components/[guild]/AddRewardButton/AddRewardButton.tsx
+++ b/src/components/[guild]/AddRewardButton/AddRewardButton.tsx
@@ -27,6 +27,7 @@ import {
   useAddRewardContext,
 } from "../AddRewardContext"
 import { CreatePoapProvider } from "../CreatePoap/components/CreatePoapContext"
+import useGuild from "../hooks/useGuild"
 import { useIsTabsStuck } from "../Tabs/Tabs"
 import { useThemeContext } from "../ThemeContext"
 import useAddReward from "./hooks/useAddReward"
@@ -37,6 +38,8 @@ const DynamicAddPoapPanel = dynamic(() => import("components/[guild]/CreatePoap"
 })
 
 const AddRewardButton = (): JSX.Element => {
+  const { roles } = useGuild()
+
   const {
     modalRef,
     selection,
@@ -84,7 +87,13 @@ const AddRewardButton = (): JSX.Element => {
     } else {
       onAddRewardSubmit({
         ...data.rolePlatforms[0].guildPlatform,
-        roleIds: data.roleIds?.filter((roleId) => !!roleId),
+        rolePlatforms: data.roleIds
+          ?.filter((roleId) => !!roleId)
+          .map((roleId) => ({
+            // We'll be able to send additional params here, like capacity & time
+            platformRoleId: roleId,
+            visibility: roles.find((role) => role.id === +roleId).visibility,
+          })),
       })
     }
   }


### PR DESCRIPTION
Visibility was hard-coded to `PUBLIC` on the `POST /v2/guilds/:id/guild-platforms` endpoint, but it'll accept detailed role data from now, so I implemented the necessary changes in this PR.