### PR TITLE
feat: `useSimpleGuild` & `useRole` hooks

### DIFF
--- a/src/components/[guild]/Requirements/components/GuildCheckout/MintGuildPin/components/ActivateGuildPinForm.tsx
+++ b/src/components/[guild]/Requirements/components/GuildCheckout/MintGuildPin/components/ActivateGuildPinForm.tsx
@@ -7,6 +7,7 @@ import { Chain } from "connectors"
 import useToast from "hooks/useToast"
 import { FormProvider, useController, useForm, useWatch } from "react-hook-form"
 import ChainPicker from "requirements/common/ChainPicker"
+import { Visibility } from "types"
 import { GUILD_PIN_CONTRACTS } from "utils/guildCheckout/constants"
 import { useMintGuildPinContext } from "../../MintGuildPinContext"
 
@@ -72,6 +73,7 @@ const ActivateGuildPinForm = (): JSX.Element => {
                 },
               ],
               rolePlatforms: [],
+              visibility: Visibility.PUBLIC,
             })
           }
         : showSuccessToastAndCloseModal,

--- a/src/components/[guild]/hooks/useGuild.ts
+++ b/src/components/[guild]/hooks/useGuild.ts
@@ -1,10 +1,10 @@
 import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
 import { useRouter } from "next/router"
-import { Guild } from "types"
+import useSWRImmutable from "swr/immutable"
+import { Guild, SimpleGuild } from "types"
 
 const useGuild = (guildId?: string | number) => {
   const router = useRouter()
-
   const id = guildId ?? router.query.guild
 
   const { data, mutate, isLoading, error, isSigned } = useSWRWithOptionalAuth<Guild>(
@@ -23,4 +23,19 @@ const useGuild = (guildId?: string | number) => {
   }
 }
 
+const useSimpleGuild = (guildId?: string | number) => {
+  const router = useRouter()
+  const id = guildId ?? router.query.guild
+
+  const { data, ...swrProps } = useSWRImmutable<SimpleGuild>(
+    id ? `/v2/guilds/${id}` : null
+  )
+
+  return {
+    ...data,
+    ...swrProps,
+  }
+}
+
 export default useGuild
+export { useSimpleGuild }

--- a/src/components/[guild]/hooks/useRole.ts
+++ b/src/components/[guild]/hooks/useRole.ts
@@ -1,0 +1,22 @@
+import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
+import { SimpleRole } from "types"
+
+const useRole = (guildId: number | string, roleId: number) => {
+  const { data, mutate, isLoading, error, isSigned } =
+    useSWRWithOptionalAuth<SimpleRole>(
+      guildId && roleId ? `/v2/guilds/${guildId}/roles/${roleId}` : null,
+      undefined,
+      undefined,
+      false
+    )
+
+  return {
+    ...data,
+    isDetailed: isSigned,
+    isLoading,
+    error,
+    mutate,
+  }
+}
+
+export default useRole

--- a/src/requirements/Guild/GuildRequirement.tsx
+++ b/src/requirements/Guild/GuildRequirement.tsx
@@ -1,6 +1,7 @@
 import { Icon, Img } from "@chakra-ui/react"
 import Link from "components/common/Link"
-import useGuild from "components/[guild]/hooks/useGuild"
+import { useSimpleGuild } from "components/[guild]/hooks/useGuild"
+import useRole from "components/[guild]/hooks/useRole"
 import DataBlockWithDate from "components/[guild]/Requirements/components/DataBlockWithDate"
 import Requirement, {
   RequirementProps,
@@ -12,24 +13,26 @@ import pluralize from "utils/pluralize"
 const HaveRole = (props: RequirementProps): JSX.Element => {
   const requirement = useRequirementContext()
 
-  const { id } = useGuild()
-  const { name, roles, urlName, isLoading } = useGuild(requirement.data.guildId)
-  const role = roles?.find((r) => r.id === requirement.data.roleId)
-
-  const isRoleInvisible = !!roles && !role
+  const { id } = useSimpleGuild()
+  const { name, urlName, isLoading } = useSimpleGuild(requirement.data.guildId)
+  const {
+    id: roleId,
+    name: roleName,
+    imageUrl: roleImageUrl,
+  } = useRole(requirement.data.guildId, requirement.data.roleId)
 
   return (
     <Requirement
       image={
-        isRoleInvisible ? (
+        !roleId ? (
           <Icon as={Detective} boxSize={6} />
         ) : (
-          role?.imageUrl &&
-          (role.imageUrl?.match("guildLogos") ? (
-            <Img src={role.imageUrl} alt="Role image" boxSize="40%" />
+          roleImageUrl &&
+          (roleImageUrl.match("guildLogos") ? (
+            <Img src={roleImageUrl} alt="Role image" boxSize="40%" />
           ) : (
             <Img
-              src={role.imageUrl}
+              src={roleImageUrl}
               alt="Role image"
               w="full"
               h="full"
@@ -41,16 +44,16 @@ const HaveRole = (props: RequirementProps): JSX.Element => {
       isImageLoading={isLoading}
       {...props}
     >
-      {isRoleInvisible ? (
+      {!roleId ? (
         "The required guild role is invisible"
       ) : (
         <>
           {"Have the "}
           <Link
-            href={`/${urlName ?? requirement.data.guildId}#role-${role?.id}`}
+            href={`/${urlName ?? requirement.data.guildId}#role-${roleId}`}
             colorScheme="blue"
           >
-            {`${role?.name ?? "unknown"} role`}
+            {`${roleName ?? "unknown"} role`}
             {id !== requirement.data.guildId &&
               ` in the ${name ?? `#${requirement.data.guildId}`} guild`}
           </Link>

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,25 @@ type GuildBase = {
   tags: Array<GuildTags>
 }
 
+type SimpleGuild = {
+  id: number
+  name: string
+  urlName: string
+  description: string
+  imageUrl: string
+  showMembers: boolean
+  hideFromExplorer: boolean
+  socialLinks: SocialLinks
+  eventSources: EventSources
+  onboardingComplete: boolean
+  memberCount: number
+  guildPin?: {
+    chain: Chain
+    isActive: boolean
+  }
+  theme: Theme
+}
+
 type BrainCardData = {
   id: string
   title: string
@@ -293,21 +312,24 @@ enum Visibility {
   HIDDEN = "HIDDEN",
 }
 
-type Role = {
+type SimpleRole = {
   id: number
   name: string
-  logic: Logic
-  anyOfNum?: number
-  members: string[]
-  imageUrl?: string
   description?: string
+  imageUrl?: string
+  logic: Logic
   memberCount: number
+  visibility: Visibility
+  position?: number
+  anyOfNum?: number
+}
+
+type Role = SimpleRole & {
+  members: string[]
   requirements: Requirement[]
   rolePlatforms: RolePlatform[]
-  visibility?: Visibility
   hiddenRequirements?: boolean
   hiddenRewards?: boolean
-  position: number
 }
 
 type GuildPlatform = {
@@ -668,6 +690,7 @@ export type {
   Guild,
   GuildAdmin,
   GuildBase,
+  SimpleGuild,
   GuildFormType,
   GuildPinMetadata,
   GuildPlatform,
@@ -688,6 +711,7 @@ export type {
   Requirement,
   RequirementType,
   Rest,
+  SimpleRole,
   Role,
   RolePlatform,
   SelectOption,


### PR DESCRIPTION
Added these 2 new hooks, so we don't fetch the guild data from the `/v2/guilds/:id/guild-page` endpoint inside `GuildRequirement`.