### PR TITLE
Fix/guild events save issue

### DIFF
--- a/src/components/[guild]/EditGuild/components/Events/EventInput.tsx
+++ b/src/components/[guild]/EditGuild/components/Events/EventInput.tsx
@@ -7,7 +7,7 @@ import {
   InputLeftElement,
   InputRightElement,
 } from "@chakra-ui/react"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, useWatch } from "react-hook-form"
 import { EventSourcesKey, GuildFormType } from "types"
 
 type Props = {
@@ -30,6 +30,13 @@ const logos: Record<EventSourcesKey, string> = {
 
 const EventInput = ({ eventSource }: Props) => {
   const { register, setValue } = useFormContext<GuildFormType>()
+  const link = useWatch({
+    name: `eventSources.${eventSource}`,
+  })
+
+  console.log("xy", link)
+
+  if (!link && link !== "") return null
 
   return (
     <InputGroup size={"lg"}>
@@ -55,4 +62,5 @@ const EventInput = ({ eventSource }: Props) => {
   )
 }
 
+export { logos, placeholders }
 export default EventInput

--- a/src/components/[guild]/EditGuild/components/Events/EventInput.tsx
+++ b/src/components/[guild]/EditGuild/components/Events/EventInput.tsx
@@ -34,8 +34,6 @@ const EventInput = ({ eventSource }: Props) => {
     name: `eventSources.${eventSource}`,
   })
 
-  console.log("xy", link)
-
   if (!link && link !== "") return null
 
   return (

--- a/src/components/[guild]/EditGuild/components/Events/Events.tsx
+++ b/src/components/[guild]/EditGuild/components/Events/Events.tsx
@@ -1,18 +1,54 @@
-import { SimpleGrid, Text } from "@chakra-ui/react"
-import EventInput from "./EventInput"
+import { Icon, Img, SimpleGrid, Text } from "@chakra-ui/react"
+import StyledSelect from "components/common/StyledSelect"
+import { Plus } from "phosphor-react"
+import { useFormContext, useWatch } from "react-hook-form"
+import { EventSourcesKey, SelectOption } from "types"
+import EventInput, { logos, placeholders } from "./EventInput"
 
-const Events = () => (
-  <>
-    <Text colorScheme="gray">
-      Guild can auto-import your events from different platforms to show them in one
-      place.
-    </Text>
-    <SimpleGrid columns={2} gap={3}>
-      <EventInput eventSource={"EVENTBRITE"} />
-      <EventInput eventSource={"LUMA"} />
-      <EventInput eventSource={"LINK3"} />
-    </SimpleGrid>
-  </>
+const EventProviders: EventSourcesKey[] = ["EVENTBRITE", "LINK3", "LUMA"]
+
+const eventOptions: SelectOption<EventSourcesKey>[] = EventProviders.map(
+  (eventProvider) => ({
+    label: placeholders[eventProvider],
+    value: eventProvider,
+    img: <Img boxSize={5} src={logos[eventProvider]} borderRadius={"full"} />,
+  })
 )
+
+const Events = () => {
+  const { control, setValue } = useFormContext()
+  const definedEventProviders = useWatch({
+    control: control,
+    name: "eventSources",
+  })
+
+  return (
+    <>
+      <Text colorScheme="gray">
+        Guild can auto-import your events from different platforms to show them in
+        one place.
+      </Text>
+      <SimpleGrid columns={2} gap={3}>
+        {eventOptions.map((event) => (
+          <EventInput key={event.value} eventSource={event.value} />
+        ))}
+        <StyledSelect
+          options={eventOptions.filter(
+            (option) => !definedEventProviders[option.value]
+          )}
+          onChange={(newValue: SelectOption<EventSourcesKey>) =>
+            setValue(`eventSources.${newValue.value}`, "")
+          }
+          placeholder="Add more"
+          value=""
+          components={{
+            DropdownIndicator: () => <Icon as={Plus} pr={2} boxSize={6} />,
+          }}
+          size="lg"
+        />
+      </SimpleGrid>
+    </>
+  )
+}
 
 export default Events


### PR DESCRIPTION
Issue: The user can't save the guild after changing the event link. The reason was the guild form sent an empty string in case some event link wasn't provided. The backend handled the empty string as a wrong link format and gave an error on save.

Solution: The front end won't register links until the user manually adds to the event source list. By the way, this was a feature request partially. 

See details here:
https://linear.app/guildxyz/issue/GUILD-1348/ultimate-event-admin-ui