### PR TITLE
fix(edit guild): handle boolean fields properly

### DIFF
--- a/src/components/[guild]/EditGuild/components/TagManager.tsx
+++ b/src/components/[guild]/EditGuild/components/TagManager.tsx
@@ -19,7 +19,9 @@ const TagManager = (): JSX.Element => {
         .filter((key) => watch(key as GuildTags))
         .map((key) => key as GuildTags)
 
-      setValue("tags", newTags)
+      setValue("tags", newTags, {
+        shouldDirty: true,
+      })
     })
     return () => subscription.unsubscribe()
   }, [watch])

--- a/src/utils/handleSubmitDirty.ts
+++ b/src/utils/handleSubmitDirty.ts
@@ -38,7 +38,7 @@ const KEYS_TO_KEEP = [
  * @returns A new object, that is a subset of formData based on dirtyFields
  */
 const formDataFilterForDirtyHelper = (dirtyFields: any, formData: any) => {
-  if (!formData) {
+  if (typeof formData === "undefined") {
     return TO_FILTER_FLAG
   }
 


### PR DESCRIPTION
We only checked if a form field value is truthy with a logical not operator inside `handleSubmitDirty`, so we actually filtered out boolean checkbox values & empty strings too (empty string is a valid form field value e.g. for a guild description), so I added a type check, let me know @cs-balazs if you think this is a good solution for the issue.