### PR TITLE
check dirty keys to keep when one of them is deleted.

### DIFF
--- a/src/components/[guild]/EditGuild/components/Events/EventInput.tsx
+++ b/src/components/[guild]/EditGuild/components/Events/EventInput.tsx
@@ -63,7 +63,11 @@ const EventInput = ({ eventSource }: Props) => {
             aria-label="Remove link"
             size="sm"
             rounded="full"
-            onClick={() => setValue(`eventSources.${eventSource}`, undefined)}
+            onClick={() =>
+              setValue(`eventSources.${eventSource}`, undefined, {
+                shouldDirty: true,
+              })
+            }
           />
         </InputRightElement>
       </InputGroup>

--- a/src/components/[guild]/EditGuild/components/SocialLinks.tsx
+++ b/src/components/[guild]/EditGuild/components/SocialLinks.tsx
@@ -9,9 +9,9 @@ import {
   InputRightElement,
   SimpleGrid,
 } from "@chakra-ui/react"
+import SocialIcon from "components/[guild]/SocialIcon"
 import FormErrorMessage from "components/common/FormErrorMessage"
 import StyledSelect from "components/common/StyledSelect"
-import SocialIcon from "components/[guild]/SocialIcon"
 import { Plus } from "phosphor-react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { GuildFormType, SelectOption, supportedSocialLinks } from "types"
@@ -58,7 +58,11 @@ const SocialLinks = (): JSX.Element => {
                     aria-label="Remove link"
                     size="sm"
                     rounded="full"
-                    onClick={() => setValue(`socialLinks.${key}`, undefined)}
+                    onClick={() =>
+                      setValue(`socialLinks.${key}`, undefined, {
+                        shouldDirty: true,
+                      })
+                    }
                   />
                 </InputRightElement>
               </InputGroup>

--- a/src/utils/handleSubmitDirty.ts
+++ b/src/utils/handleSubmitDirty.ts
@@ -51,23 +51,8 @@ const formDataFilterForDirtyHelper = (dirtyFields: any, formData: any) => {
   }
 
   if (typeof dirtyFields === "object") {
-    const extendedDiryFields = JSON.parse(JSON.stringify(dirtyFields))
-
-    Object.entries(dirtyFields).forEach(([key]) => {
-      const keyIsDirtyFrom = DIRTY_KEYS_TO_KEEP.find(
-        (keeyToKeep) => keeyToKeep === key
-      )
-      const allfields = formData[keyIsDirtyFrom]
-
-      if (allfields)
-        Object.entries(allfields).forEach(([fieldKey, value]) => {
-          if (!extendedDiryFields[keyIsDirtyFrom].key)
-            extendedDiryFields[keyIsDirtyFrom][fieldKey] = value
-        })
-    })
-
     const newObj = Object.fromEntries(
-      Object.entries(extendedDiryFields)
+      Object.entries(dirtyFields)
         .map(([key, value]) => [
           key,
           formDataFilterForDirtyHelper(value, formData[key]),
@@ -76,6 +61,12 @@ const formDataFilterForDirtyHelper = (dirtyFields: any, formData: any) => {
           ([key, value]) => value !== TO_FILTER_FLAG && !KEYS_TO_FILTER.has(key)
         )
     )
+
+    DIRTY_KEYS_TO_KEEP.forEach((keyToKeep) => {
+      if (keyToKeep in dirtyFields) {
+        newObj[keyToKeep] = formData[keyToKeep]
+      }
+    })
 
     const isEmpty = Object.keys(newObj).length <= 0
 
@@ -86,12 +77,6 @@ const formDataFilterForDirtyHelper = (dirtyFields: any, formData: any) => {
 
     KEYS_TO_KEEP.forEach((keyToKeep) => {
       if (keyToKeep in formData) {
-        newObj[keyToKeep] = formData[keyToKeep]
-      }
-    })
-
-    DIRTY_KEYS_TO_KEEP.forEach((keyToKeep) => {
-      if (keyToKeep in newObj) {
         newObj[keyToKeep] = formData[keyToKeep]
       }
     })

--- a/src/utils/handleSubmitDirty.ts
+++ b/src/utils/handleSubmitDirty.ts
@@ -51,8 +51,23 @@ const formDataFilterForDirtyHelper = (dirtyFields: any, formData: any) => {
   }
 
   if (typeof dirtyFields === "object") {
+    const extendedDiryFields = JSON.parse(JSON.stringify(dirtyFields))
+
+    Object.entries(dirtyFields).forEach(([key]) => {
+      const keyIsDirtyFrom = DIRTY_KEYS_TO_KEEP.find(
+        (keeyToKeep) => keeyToKeep === key
+      )
+      const allfields = formData[keyIsDirtyFrom]
+
+      if (allfields)
+        Object.entries(allfields).forEach(([fieldKey, value]) => {
+          if (!extendedDiryFields[keyIsDirtyFrom].key)
+            extendedDiryFields[keyIsDirtyFrom][fieldKey] = value
+        })
+    })
+
     const newObj = Object.fromEntries(
-      Object.entries(dirtyFields)
+      Object.entries(extendedDiryFields)
         .map(([key, value]) => [
           key,
           formDataFilterForDirtyHelper(value, formData[key]),


### PR DESCRIPTION
The issue:
We can't delete the social and event links from the guild editor drawer.

Context and Expected Behaviour:
When we delete a link, we should send the rest to the backend because it will delete the links not in the request. 

The solution has two parts.
Part 1:
When we set the field to 'undefined' it won't be dirty. So I added an option to set them as dirty.

Part 2:
- We need to check the dirty fields to see if one of them is a key from 'DIRTY_KEYS_TO_KEEP'
- We set all the fields dirty to send to the backend.
- The rest of the current algorithm will filter the 'undefined' field as of now.
- As a result, we will send the fields not dirty as dirty with the current value and won't send the deleted.

Edge case:
The fix is not perfect, unfortunately, because it doesn't work when there is only one item in the list. It will send nothing. 

