### PR TITLE
Wagmi Safe fix

### DIFF
--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -12,7 +12,7 @@ import {
   useState,
 } from "react"
 import { PlatformName } from "types"
-import { useAccount, useSwitchNetwork } from "wagmi"
+import { useAccount, useConnect, useSwitchNetwork } from "wagmi"
 import PlatformMergeErrorAlert from "./components/PlatformMergeErrorAlert"
 import WalletSelectorModal from "./components/WalletSelectorModal"
 import useConnectFromLocalStorage from "./hooks/useConnectFromLocalStorage"
@@ -37,13 +37,26 @@ const Web3Connection = createContext({
     _addressOrDomain: string,
     _platformName: PlatformName
   ) => {},
+  isInSafeContext: false,
 })
 
 const Web3ConnectionManager = ({
   children,
 }: PropsWithChildren<any>): JSX.Element => {
   const { isConnected } = useAccount()
+  const { connectors } = useConnect()
   const router = useRouter()
+
+  const [isInSafeContext, setIsInSafeContext] = useState(false)
+
+  useEffect(() => {
+    if (!connectors) return
+    const safeConnector = connectors.find(({ id }) => id === "safe")
+    if (!safeConnector) return
+    safeConnector.once("connect", () => {
+      setIsInSafeContext(true)
+    })
+  }, [connectors])
 
   const {
     isOpen: isWalletSelectorModalOpen,
@@ -122,6 +135,7 @@ const Web3ConnectionManager = ({
         isDelegateConnection,
         setIsDelegateConnection,
         isNetworkChangeInProgress,
+        isInSafeContext,
       }}
     >
       {children}

--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -12,7 +12,7 @@ import {
   useState,
 } from "react"
 import { PlatformName } from "types"
-import { useAccount, useConnect, useSwitchNetwork } from "wagmi"
+import { useAccount, useSwitchNetwork } from "wagmi"
 import PlatformMergeErrorAlert from "./components/PlatformMergeErrorAlert"
 import WalletSelectorModal from "./components/WalletSelectorModal"
 import useConnectFromLocalStorage from "./hooks/useConnectFromLocalStorage"
@@ -43,20 +43,15 @@ const Web3Connection = createContext({
 const Web3ConnectionManager = ({
   children,
 }: PropsWithChildren<any>): JSX.Element => {
-  const { isConnected } = useAccount()
-  const { connectors } = useConnect()
+  const { isConnected, connector } = useAccount()
   const router = useRouter()
 
   const [isInSafeContext, setIsInSafeContext] = useState(false)
 
   useEffect(() => {
-    if (!connectors) return
-    const safeConnector = connectors.find(({ id }) => id === "safe")
-    if (!safeConnector) return
-    safeConnector.once("connect", () => {
-      setIsInSafeContext(true)
-    })
-  }, [connectors])
+    if (!isConnected || connector.id !== "safe") return
+    setIsInSafeContext(true)
+  }, [isConnected, connector])
 
   const {
     isOpen: isWalletSelectorModalOpen,

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -25,7 +25,6 @@ import { ArrowLeft, ArrowSquareOut } from "phosphor-react"
 import { useEffect, useRef, useState } from "react"
 import ReCAPTCHA from "react-google-recaptcha"
 import { useAccount, useConnect, useDisconnect } from "wagmi"
-import { SafeConnector } from "wagmi/dist/connectors/safe"
 import { useWeb3ConnectionManager } from "../../Web3ConnectionManager"
 import ConnectorButton from "./components/ConnectorButton"
 import DelegateCashButton from "./components/DelegateCashButton"
@@ -98,12 +97,12 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
   const [isInSafeContext, setIsInSafeContext] = useState(false)
 
   useEffect(() => {
-    const [, , , safeConnector] = connectors
-    const conn = safeConnector as SafeConnector
-    conn.once("connect", () => {
+    const safeConnector = connectors?.find(({ id }) => id === "safe")
+    if (!safeConnector) return
+    safeConnector.once("connect", () => {
       setIsInSafeContext(true)
     })
-  }, [])
+  }, [connectors])
 
   return (
     <>

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -20,9 +20,10 @@ import { Error } from "components/common/Error"
 import Link from "components/common/Link"
 import { Modal } from "components/common/Modal"
 import ModalButton from "components/common/ModalButton"
+import { SAFE_CONTEXT_FLAG } from "connectors"
 import { useRouter } from "next/router"
 import { ArrowLeft, ArrowSquareOut } from "phosphor-react"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 import ReCAPTCHA from "react-google-recaptcha"
 import { useAccount, useConnect, useDisconnect } from "wagmi"
 import { useWeb3ConnectionManager } from "../../Web3ConnectionManager"
@@ -93,20 +94,6 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
   const isWalletConnectModalActive = useIsWalletConnectModalActive()
 
   const recaptchaRef = useRef<ReCAPTCHA>()
-
-  const [isInSafeContext, setIsInSafeContext] = useState(false)
-
-  useEffect(() => {
-    console.log("CONNECTORS", connectors)
-    const safeConnector = connectors?.find(({ id }) => id === "safe")
-
-    console.log("SAFE CONNECTOR", safeConnector)
-    if (!safeConnector) return
-    safeConnector.once("connect", () => {
-      console.log("SAFE CONNECTED")
-      setIsInSafeContext(true)
-    })
-  }, [connectors])
 
   return (
     <>
@@ -191,7 +178,7 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
             )}
             <Stack spacing="0">
               {connectors
-                .filter((conn) => isInSafeContext || conn.id !== "safe")
+                .filter((conn) => window[SAFE_CONTEXT_FLAG] || conn.id !== "safe")
                 .map((conn) => (
                   <CardMotionWrapper key={conn.id}>
                     <ConnectorButton

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -20,7 +20,6 @@ import { Error } from "components/common/Error"
 import Link from "components/common/Link"
 import { Modal } from "components/common/Modal"
 import ModalButton from "components/common/ModalButton"
-import { SAFE_CONTEXT_FLAG } from "connectors"
 import { useRouter } from "next/router"
 import { ArrowLeft, ArrowSquareOut } from "phosphor-react"
 import { useEffect, useRef } from "react"
@@ -86,7 +85,7 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
 
   const shouldLinkToUser = useShouldLinkToUser()
 
-  const { isDelegateConnection, setIsDelegateConnection } =
+  const { isDelegateConnection, setIsDelegateConnection, isInSafeContext } =
     useWeb3ConnectionManager()
 
   const isConnectedAndKeyPairReady = isConnected && ready
@@ -178,7 +177,7 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
             )}
             <Stack spacing="0">
               {connectors
-                .filter((conn) => window[SAFE_CONTEXT_FLAG] || conn.id !== "safe")
+                .filter((conn) => isInSafeContext || conn.id !== "safe")
                 .map((conn) => (
                   <CardMotionWrapper key={conn.id}>
                     <ConnectorButton

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -97,9 +97,13 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
   const [isInSafeContext, setIsInSafeContext] = useState(false)
 
   useEffect(() => {
+    console.log("CONNECTORS", connectors)
     const safeConnector = connectors?.find(({ id }) => id === "safe")
+
+    console.log("SAFE CONNECTOR", safeConnector)
     if (!safeConnector) return
     safeConnector.once("connect", () => {
+      console.log("SAFE CONNECTED")
       setIsInSafeContext(true)
     })
   }, [connectors])

--- a/src/connectors.ts
+++ b/src/connectors.ts
@@ -6,6 +6,8 @@ import { SafeConnector } from "wagmi/connectors/safe"
 import { WalletConnectConnector } from "wagmi/connectors/walletConnect"
 import { publicProvider } from "wagmi/providers/public"
 
+export const SAFE_CONTEXT_FLAG = "safeAutoConnected"
+
 const { chains, publicClient } = configureChains(Object.values(CHAIN_CONFIG), [
   publicProvider(),
 ])
@@ -50,5 +52,10 @@ const connectors = [
     },
   }),
 ]
+
+const [, , , safeConnector] = connectors
+safeConnector.once("connect", () => {
+  ;(window as any)[SAFE_CONTEXT_FLAG] = true
+})
 
 export { connectors, publicClient }

--- a/src/connectors.ts
+++ b/src/connectors.ts
@@ -6,8 +6,6 @@ import { SafeConnector } from "wagmi/connectors/safe"
 import { WalletConnectConnector } from "wagmi/connectors/walletConnect"
 import { publicProvider } from "wagmi/providers/public"
 
-export const SAFE_CONTEXT_FLAG = "safeAutoConnected"
-
 const { chains, publicClient } = configureChains(Object.values(CHAIN_CONFIG), [
   publicProvider(),
 ])
@@ -52,10 +50,5 @@ const connectors = [
     },
   }),
 ]
-
-const [, , , safeConnector] = connectors
-safeConnector.once("connect", () => {
-  ;(window as any)[SAFE_CONTEXT_FLAG] = true
-})
 
 export { connectors, publicClient }


### PR DESCRIPTION
I didn't find a way to detect Safe context like we did before, instead added a new `isInSafeContext` state, which is toggled to true, when the Safe connector is connected. This works because in order for a Safe app to work, it needs to auto-connect to the Safe account (which the wagmi connector seems to do by default, unlike the web3-react one). Therefore if I disconnect my Safe account, I can reconnect from the modal, and if I'm outside the context, I won't see the Safe option, as the connector didn't auto-connect