### PR TITLE
Adding platformGuildId property to DiscordCaptchaSwitch

### DIFF
--- a/src/platforms/Discord/DiscordCardMenu/components/DiscordCaptchaSwitch.tsx
+++ b/src/platforms/Discord/DiscordCardMenu/components/DiscordCaptchaSwitch.tsx
@@ -55,6 +55,7 @@ const DiscordCaptchaSwitch = ({ serverId }: Props): JSX.Element => {
         ...guildPlatform.platformGuildData,
         needCaptcha: newIsChecked,
       },
+      platformGuildId: guildPlatform.platformGuildId,
     })
   }
 


### PR DESCRIPTION
This PR should fix the runner error's, when a Guild Admin switches the Discord captcha on and off.