### PR TITLE
Typo fix Update detectCircularDependencies.ts

### DIFF
--- a/scripts/detectCircularDependencies.ts
+++ b/scripts/detectCircularDependencies.ts
@@ -35,7 +35,7 @@ async function main() {
 export async function determineCirculars(): Promise<string[][]> {
   return new Promise((resolve) => {
     void parseDependencyTree("./**/*.ts*", {
-      // by transforming all files to javascript we avoid detecting circular type dependencies, whhich dont hurt at runtime
+      // by transforming all files to javascript we avoid detecting circular type dependencies, which dont hurt at runtime
       transform: true,
       exclude: /node_modules\/*/,
     }).then((tree) => {


### PR DESCRIPTION
Typo in the code comment describing the `transform` option.
The word "whhich" has been corrected to "**which**" to improve clarity and readability.  