### PR TITLE
docs: update 404 link

### DIFF
--- a/src/requirements/Snapshot/components/Strategy/components/SingleStrategy.tsx
+++ b/src/requirements/Snapshot/components/Strategy/components/SingleStrategy.tsx
@@ -216,7 +216,7 @@ const SingleStrategy = ({ baseFieldPath, index }: Props): JSX.Element => {
                   // case "object":
                   //   return null
                   // Unsupported field
-                  // e.g.: https://github.com/snapshot-labs/snapshot-strategies/blob/master/src/strategies/ctsi-staking/schema.json
+                  // e.g.: https://github.com/snapshot-labs/snapshot-strategies/blob/master/src/strategies/ctsi-staking-pool/schema.json
                 }
               })()}
 


### PR DESCRIPTION
Hi! The comment in `SingleStrategy.tsx` referenced an outdated strategy schema example that no longer exists. The original link to `ctsi-staking/schema.json` resulted in a 404 error.