### PR TITLE
fix: add missing optional chaining for blockExplorers.default

### DIFF
--- a/src/wagmiConfig/chains.ts
+++ b/src/wagmiConfig/chains.ts
@@ -103,7 +103,7 @@ const generateChainConfig = (
     ...chain.nativeCurrency,
     iconUrl: nativeCurrencyIconUrl,
   },
-  blockExplorerUrl: chain.blockExplorers?.default.url ?? "",
+  blockExplorerUrl: chain.blockExplorers?.default?.url ?? "",
 })
 
 const ETH_ICON =


### PR DESCRIPTION
Prevents a potential runtime error when blockExplorers.default is undefined by adding optional chaining